### PR TITLE
Add Ghost Inspector JSON Format

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,42 @@ GhostInspector.downloadSuiteSeleniumJson('[suite-id]', 'suite.zip', function (er
 });
 ```
 
+#### GhostInspector.downloadSuiteGhostJson(suiteId, dest, [callback])
+Download a file of all tests in this suite in Ghostinspector JSON format
+
+```js
+// Example using await
+try {
+    await GhostInspector.downloadSuiteGhostJson('[suite-id]', 'suite.json');
+} catch (err) {
+    console.error(err);
+}
+
+// Example using a callback
+GhostInspector.downloadSuiteGhostJson('[suite-id]', 'suite.json', function (err) {
+    if (err) return console.error(err);
+    console.log('File saved to suite.json.');
+});
+```
+
+#### GhostInspector.downloadTestGhostJson(testId, dest, [callback])
+Download a file of a single tests in Ghostinspector JSON format
+
+```js
+// Example using await
+try {
+    await GhostInspector.downloadTestGhostJson('[test-id]', 'test.json');
+} catch (err) {
+    console.error(err);
+}
+
+// Example using a callback
+GhostInspector.downloadTestGhostJson('[test-id]', 'test.json', function (err) {
+    if (err) return console.error(err);
+    console.log('File saved to test.json.');
+});
+```
+
 #### GhostInspector.importTest(suiteId, test, [callback])
 Import a test in JSON or HTML (Selenium IDE v1) format.
 ```js

--- a/index.js
+++ b/index.js
@@ -270,6 +270,14 @@ class GhostInspector {
     return this.download(`/suites/${suiteId}/export/selenium-side/`, dest, callback)
   }
 
+  async downloadSuiteGhostJson (suiteId, dest, callback) {
+    return this.download(`/suites/${suiteId}/export/json/`, dest, callback)
+  }
+
+  async downloadTestGhostJson (testId, dest, callback) {
+    return this.download(`/tests/${testId}/export/json/`, dest, callback)
+  }
+
   async getTests (callback) {
     return this.request('GET', '/tests/', callback)
   }


### PR DESCRIPTION
In order to make possible to save tests in Ghost Inspector JSON Format, that could be easily used for restoring tests in your Suites on ghostinspector.com, I added two new methods:

`downloadSuiteGhostJson()` and `downloadTestGhostJson()`

see also:
https://ghostinspector.com/docs/api/suites/#json
and
https://ghostinspector.com/docs/api/tests/#json

README was also adjusted accodringly.