### PR TITLE
update kebab-case to camelCase for all params

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,22 +48,22 @@ try {
 CLI quickstart:
 
 ```
-❯ ghost-inspector test execute <my-test-id> --browser Firefox --myVariable "some variable" --errorOnFail
+❯ ghost-inspector test execute <testId> --browser Firefox --myVariable "some variable" --errorOnFail
 ```
 
 ### Exit status control for CI systems
 
-Under an automated build environment it makes sense to have a command return a non-success status when things are failing. By default the CLI will always return a success (`0`) status when executing tests or suites, however you can have the command fail for a non-passing test or suite status (`--errorOnFailing`), a non-passing screenshot status (`--errorOnScreenshotFail`) or both when waiting for a result:
+Under an automated build environment it makes sense to have a command return a non-success status when things are failing. By default the CLI will always return a success (`0`) status when executing tests or suites, however you can have the command fail for a non-passing test or suite status (`--errorOnFail`), a non-passing screenshot status (`--errorOnScreenshotFail`) or both when waiting for a result:
 
 ```
 # exit with error code when failing
-❯ ghost-inspector test execute <my-test-id> --errorOnFail
+❯ ghost-inspector test execute <testId> --errorOnFail
 
 # exit with error code when screenshot failing (will ignore `passing`)
-❯ ghost-inspector test execute <my-test-id> --errorOnScreenshotFail
+❯ ghost-inspector test execute <testId> --errorOnScreenshotFail
 
 # exit with error code if `passing` or `screenshotComparePassing` is `false`
-❯ ghost-inspector test execute <my-test-id> --errorOnFail --errorOnScreenshotFail
+❯ ghost-inspector test execute <testId> --errorOnFail --errorOnScreenshotFail
 
 ```
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -4,6 +4,9 @@
 global.describe = () => {}
 
 require('yargs/yargs')(process.argv.slice(2))
+  .parserConfiguration({
+    'camel-case-expansion': false,
+  })
   .option('apiKey', {
     description:
       'Your Ghost Inspector API key. You may also pass GHOST_INSPECTOR_API_KEY through your environment.',

--- a/bin/commands/folder/create.js
+++ b/bin/commands/folder/create.js
@@ -1,7 +1,7 @@
 const helpers = require('../../helpers')
 
 module.exports = {
-  command: 'create <organization-id> <folder-name>',
+  command: 'create <organizationId> <folderName>',
   desc: 'Create a folder.',
   builder: {},
   handler: async function (argv) {

--- a/bin/commands/folder/get.js
+++ b/bin/commands/folder/get.js
@@ -1,7 +1,7 @@
 const helpers = require('../../helpers')
 
 module.exports = {
-  command: 'get <folder-id>',
+  command: 'get <folderId>',
   desc: 'Fetch a single folder.',
   builder: {},
   handler: async function (argv) {

--- a/bin/commands/folder/list-suites.js
+++ b/bin/commands/folder/list-suites.js
@@ -1,7 +1,7 @@
 const helpers = require('../../helpers')
 
 module.exports = {
-  command: 'list-suites <folder-id>',
+  command: 'list-suites <folderId>',
   desc: 'Fetch an array of all the suites in a folder.',
   builder: {},
   handler: async function (argv) {

--- a/bin/commands/folder/update.js
+++ b/bin/commands/folder/update.js
@@ -1,8 +1,8 @@
 const helpers = require('../../helpers')
 
 module.exports = {
-  command: 'update <folder-id> <folder-name>',
-  desc: 'Update a folder with new <folder-name>.',
+  command: 'update <folderId> <folderName>',
+  desc: 'Update a folder with new <folderName>.',
   builder: {},
   handler: async function (argv) {
     const client = helpers.getClient(argv)

--- a/bin/commands/organization/get-running.js
+++ b/bin/commands/organization/get-running.js
@@ -1,7 +1,7 @@
 const helpers = require('../../helpers')
 
 module.exports = {
-  command: 'get-running <organization-id>',
+  command: 'get-running <organizationId>',
   desc:
     'Fetch a list of the currently-executing results for the entire organization and return the results.',
   builder: {},

--- a/bin/commands/suite-result/list.js
+++ b/bin/commands/suite-result/list.js
@@ -1,7 +1,7 @@
 const helpers = require('../../helpers')
 
 module.exports = {
-  command: 'list <suite-id>',
+  command: 'list <suiteId>',
   desc: 'Fetch an array of suite results for a suite.',
   builder: {},
   handler: async function (argv) {

--- a/bin/commands/suite/create.js
+++ b/bin/commands/suite/create.js
@@ -1,7 +1,7 @@
 const helpers = require('../../helpers')
 
 module.exports = {
-  command: 'create <organization-id> <suite-name>',
+  command: 'create <organizationId> <suiteName>',
   desc: 'Create a suite.',
   builder: {},
   handler: async function (argv) {

--- a/bin/commands/suite/download.js
+++ b/bin/commands/suite/download.js
@@ -1,19 +1,19 @@
 const helpers = require('../../helpers')
 
 module.exports = {
-  command: 'download <suite-id>',
+  command: 'download <suiteId>',
   desc: 'Download a single suite.',
   builder: (yargs) => {
     yargs.options({
       destination: {
-        description: 'Path to local destination for output. Defaults to "suite-<suite-id>.zip"',
+        description: 'Path to local destination for output. Defaults to "suite-<suiteId>.zip"',
       },
       format: {
         description: 'Desired output format',
         choices: ['json', 'html', 'side'],
         default: 'json',
       },
-      'include-imports': {
+      includeImports: {
         description:
           'Bundle imported suites in the export when provided (currenlty for .json exports only)',
         type: 'boolean',

--- a/bin/commands/suite/duplicate.js
+++ b/bin/commands/suite/duplicate.js
@@ -1,7 +1,7 @@
 const helpers = require('../../helpers')
 
 module.exports = {
-  command: 'duplicate <suite-id>',
+  command: 'duplicate <suiteId>',
   desc: 'Duplicate a suite.',
   builder: {},
   handler: async function (argv) {

--- a/bin/commands/suite/execute.js
+++ b/bin/commands/suite/execute.js
@@ -1,7 +1,7 @@
 const helpers = require('../../helpers')
 
 module.exports = {
-  command: 'execute <suite-id> [options]',
+  command: 'execute <suiteId> [options]',
   desc: 'Execute a suite with the provided options.',
 
   builder: (yargs) => {

--- a/bin/commands/suite/get.js
+++ b/bin/commands/suite/get.js
@@ -1,7 +1,7 @@
 const helpers = require('../../helpers')
 
 module.exports = {
-  command: 'get <suite-id>',
+  command: 'get <suiteId>',
   desc: 'Fetch a single suite.',
   builder: {},
   handler: async function (argv) {

--- a/bin/commands/suite/import-test.js
+++ b/bin/commands/suite/import-test.js
@@ -1,7 +1,7 @@
 const helpers = require('../../helpers')
 
 module.exports = {
-  command: 'import-test <suite-id> <file>',
+  command: 'import-test <suiteId> <file>',
   desc:
     'Import a test in JSON or HTML (Selenium IDE v1) format. <file> must be local path on-disk to JSON test file.',
   builder: {},

--- a/bin/commands/suite/list-results.js
+++ b/bin/commands/suite/list-results.js
@@ -1,7 +1,7 @@
 const helpers = require('../../helpers')
 
 module.exports = {
-  command: 'list-results <suite-id>',
+  command: 'list-results <suiteId>',
   desc:
     'Fetch an array containing the results for a suite. Results are returned in reverse chronological order (newest first).',
   builder: (yargs) => {

--- a/bin/commands/suite/list-tests.js
+++ b/bin/commands/suite/list-tests.js
@@ -1,7 +1,7 @@
 const helpers = require('../../helpers')
 
 module.exports = {
-  command: 'list-tests <suite-id>',
+  command: 'list-tests <suiteId>',
   desc: 'Fetch an array of all the tests in a suite.',
   builder: {},
   handler: async function (argv) {

--- a/bin/commands/suite/update.js
+++ b/bin/commands/suite/update.js
@@ -1,7 +1,7 @@
 const helpers = require('../../helpers')
 
 module.exports = {
-  command: 'update <suite-id>',
+  command: 'update <suiteId>',
   desc: 'Update a suite.',
   builder: (yargs) => {
     yargs.options({

--- a/bin/commands/test-result/cancel.js
+++ b/bin/commands/test-result/cancel.js
@@ -1,7 +1,7 @@
 const helpers = require('../../helpers')
 
 module.exports = {
-  command: 'cancel <result-id>',
+  command: 'cancel <resultId>',
   desc: 'Cancel an active test run.',
   builder: {},
   handler: async function (argv) {

--- a/bin/commands/test-result/get.js
+++ b/bin/commands/test-result/get.js
@@ -1,7 +1,7 @@
 const helpers = require('../../helpers')
 
 module.exports = {
-  command: 'get <result-id>',
+  command: 'get <resultId>',
   desc: 'Fetch a single test result.',
   builder: {},
   handler: async function (argv) {

--- a/bin/commands/test-result/wait.js
+++ b/bin/commands/test-result/wait.js
@@ -1,16 +1,16 @@
 const helpers = require('../../helpers')
 
 module.exports = {
-  command: 'wait <result-id>',
+  command: 'wait <resultId>',
   desc: 'Poll a running test result until complete.',
   builder: (yargs) => {
     yargs.options({
-      'error-on-fail': {
+      errorOnFail: {
         description:
           'Exit the command with a non-0 status if the test or suite passing value is not `true`. Ignored when used with --immediate',
         default: false,
       },
-      'error-on-screenshot-fail': {
+      errorOnScreenshotFail: {
         description:
           'Exit the command with a non-0 status if the test or suite screenshotComparePassing value is not `true`. Ignored when used with --immediate',
         default: false,

--- a/bin/commands/test/accept-screenshot.js
+++ b/bin/commands/test/accept-screenshot.js
@@ -1,7 +1,7 @@
 const helpers = require('../../helpers')
 
 module.exports = {
-  command: 'accept-screenshot <test-id>',
+  command: 'accept-screenshot <testId>',
   desc:
     "Accept the current screenshot as the new baseline for a test, will throw/return an error if the test's screenshot is already passing, or if screenshot comparison is disabled.",
   builder: {},

--- a/bin/commands/test/delete.js
+++ b/bin/commands/test/delete.js
@@ -1,7 +1,7 @@
 const helpers = require('../../helpers')
 
 module.exports = {
-  command: 'delete <test-id>',
+  command: 'delete <testId>',
   desc: 'Delete a test.',
   builder: {},
   handler: async function (argv) {

--- a/bin/commands/test/download.js
+++ b/bin/commands/test/download.js
@@ -1,12 +1,12 @@
 const helpers = require('../../helpers')
 
 module.exports = {
-  command: 'download <test-id>',
+  command: 'download <testId>',
   desc: 'Download a single test.',
   builder: (yargs) => {
     yargs.options({
       destination: {
-        description: 'Path to local destination for output. Defaults to "test-<test-id>.<format>"',
+        description: 'Path to local destination for output. Defaults to "test-<testId>.<format>"',
       },
       format: {
         description: 'Desired output format',

--- a/bin/commands/test/duplicate.js
+++ b/bin/commands/test/duplicate.js
@@ -1,7 +1,7 @@
 const helpers = require('../../helpers')
 
 module.exports = {
-  command: 'duplicate <test-id>',
+  command: 'duplicate <testId>',
   desc: 'Duplicate a test.',
   builder: {},
   handler: async function (argv) {

--- a/bin/commands/test/execute-on-demand.js
+++ b/bin/commands/test/execute-on-demand.js
@@ -1,7 +1,7 @@
 const helpers = require('../../helpers')
 
 module.exports = {
-  command: 'execute-on-demand <organization-id> <file> [options]',
+  command: 'execute-on-demand <organizationId> <file> [options]',
   desc:
     'Execute an on-demand test against your organization providing the path to your local JSON <file>.',
 

--- a/bin/commands/test/execute.js
+++ b/bin/commands/test/execute.js
@@ -1,14 +1,14 @@
 const helpers = require('../../helpers')
 
 module.exports = {
-  command: 'execute <test-id> [options]',
+  command: 'execute <testId> [options]',
   desc: 'Execute a test with the provided options.',
 
   builder: (yargs) => {
     yargs.options({
       ...helpers.getCommonExecutionOptions(),
       // execute-test only
-      'screenshot-compare-baseline-result': {
+      screenshotCompareBaselineResult: {
         description:
           'The ID of any completed test result across your organization to use as the baseline for the screenshot comparison Will be ignored if screenshot comparison or visual capture is disabled.',
       },

--- a/bin/commands/test/execute.spec.js
+++ b/bin/commands/test/execute.spec.js
@@ -355,4 +355,31 @@ describe('execute --immediate=false', function () {
       })
     })
   })
+
+  describe('parameter handling', function () {
+    beforeEach(function () {
+      this.setUpHandler({
+        commandModule: './test/execute',
+        clientMethod: 'executeTest',
+        clientMethodResponse: [{ name: 'My test', _id: '98765' }, null, true],
+      })
+    })
+    it('should pass in user variables with hypens', async function () {
+      this.setExpectedExitCode(1)
+      await this.testPlainOutput({
+        handlerInput: {
+          testId: 'my-test-id',
+          myVar: 'foobar',
+          'my-other-var': 'foobaz',
+          immediate: false,
+          errorOnFail: true,
+        },
+        expectedClientArgs: [
+          'my-test-id',
+          { myVar: 'foobar', 'my-other-var': 'foobaz', immediate: false },
+        ],
+        expectedOutput: [['Result: My test (98765)']],
+      })
+    })
+  })
 })

--- a/bin/commands/test/get-running.js
+++ b/bin/commands/test/get-running.js
@@ -1,7 +1,7 @@
 const helpers = require('../../helpers')
 
 module.exports = {
-  command: 'get-results-running <test-id>',
+  command: 'get-results-running <testId>',
   desc: 'Fetch a list of the currently-executing results for this test and return the result.',
 
   builder: {},

--- a/bin/commands/test/get.js
+++ b/bin/commands/test/get.js
@@ -1,7 +1,7 @@
 const helpers = require('../../helpers')
 
 module.exports = {
-  command: 'get <test-id>',
+  command: 'get <testId>',
   desc: 'Fetch a single test.',
   builder: {},
   handler: async function (argv) {

--- a/bin/commands/test/list-results.js
+++ b/bin/commands/test/list-results.js
@@ -1,7 +1,7 @@
 const helpers = require('../../helpers')
 
 module.exports = {
-  command: 'list-results <test-id>',
+  command: 'list-results <testId>',
   desc:
     'Fetch an array containing the results for a test. Results are returned in reverse chronological order (newest first).',
   builder: (yargs) => {

--- a/bin/commands/test/update.js
+++ b/bin/commands/test/update.js
@@ -1,7 +1,7 @@
 const helpers = require('../../helpers')
 
 module.exports = {
-  command: 'update <test-id>',
+  command: 'update <testId>',
   desc: 'Update a test.',
   builder: (yargs) => {
     yargs.options({

--- a/bin/helpers.js
+++ b/bin/helpers.js
@@ -4,15 +4,7 @@ const fs = require('fs')
 const path = require('path')
 
 /**
- * Yargs duplicates every argument like so:
- *
- *   {
- *     'foo-bar': 'baz',
- *     fooBar: 'baz',
- *   }
- *
- * And also includes some yargs-specific details (eg '$0') that we don't need.
- * This cleans those up so the output is compatible with the Ghost Inspector
+ * Clean up arguments so the output is compatible with the Ghost Inspector
  * Node.js client without further modification.
  */
 const cleanArgs = (args) => {
@@ -27,12 +19,6 @@ const cleanArgs = (args) => {
   delete args['errorOnFail']
   delete args['errorOnScreenshotFail']
 
-  // remove hypenated args 'foo-bar'
-  Object.keys(args).forEach((key) => {
-    if (key.includes('-')) {
-      delete args[key]
-    }
-  })
   return args
 }
 
@@ -63,31 +49,31 @@ const getCommonExecutionOptions = () => {
         'Alternate browser to use for this execution. The following options are available: chrome (Latest version), chrome- (Specific version of Chrome, for example chrome-83), firefox (Latest version), firefox- (Specific version of Firefox, for example firefox-77). Provide multiple --browser arguments to trigger multiple executions.',
       type: 'string',
     },
-    'data-file': {
+    dataFile: {
       description: 'Path to local CSV file containing a row of variable values for each test run',
     },
-    'disable-notifications': {
+    disableNotifications: {
       description: 'Disable all notifications for this execution only when provided',
       type: 'boolean',
     },
-    'disable-visuals': {
+    disableVisuals: {
       description: 'Disable capturing screenshots and video for this execution only when provided',
       type: 'boolean',
     },
-    'error-on-fail': {
+    errorOnFail: {
       description:
         'Exit the command with a non-0 status if the test or suite passing value is not `true`. Ignored when used with --immediate',
       default: false,
     },
-    'error-on-screenshot-fail': {
+    errorOnScreenshotFail: {
       description:
         'Exit the command with a non-0 status if the test or suite screenshotComparePassing value is not `true`. Ignored when used with --immediate',
       default: false,
     },
-    'http-auth-password': {
+    httpAuthPassword: {
       description: 'Alternate HTTP authentication password to use for this execution only',
     },
-    'http-auth-username': {
+    httpAuthUsername: {
       description: 'Alternate HTTP authentication username to use for this execution only',
     },
     immediate: {
@@ -95,7 +81,7 @@ const getCommonExecutionOptions = () => {
       type: 'boolean',
       default: false,
     },
-    'max-concurrent-data-rows': {
+    maxConcurrentDataRows: {
       description:
         'Specify the max number of rows to execute simultaneously when executing a test using dataFile.',
     },
@@ -103,39 +89,39 @@ const getCommonExecutionOptions = () => {
       description:
         'Geo-location for this execution, defaults to "us-east-1". Use `ghost-inspector test-runner-ips` to see all available regions. Provide multiple --region params to trigger multiple executions.',
     },
-    'screenshot-compare-enabled': {
+    screenshotCompareEnabled: {
       description: 'Enable screenshot comparison for this execution only when provided',
       type: Boolean,
     },
-    'screenshot-compare-threshold': {
+    screenshotCompareThreshold: {
       description:
         'Use a number between 0.0 and 1.0 to set the tolerance when comparing screenshots (for this execution only). Will be ignored if screenshot comparison or visual capture is disabled.',
       type: 'number',
     },
-    'screenshot-exclusions': {
+    screenshotExclusions: {
       description:
         'Comma-separated list of CSS selectors. Elements matched by this CSS will be hidden before the screenshot is taken (for this execution only). Will be ignored if screenshot comparison or visual capture is disabled.',
     },
-    'screenshot-target': {
+    screenshotTarget: {
       description:
         'Use a CSS or XPath selector. Screenshot will be taken of the element specified instead of the whole page (for this execution only). Will be ignored if screenshot comparison or visual capture is disabled.',
     },
-    'slack-channel': {
+    slackChannel: {
       description: 'Specify the Slack channel to notify for this test run.',
     },
-    'start-url': {
+    startUrl: {
       description: 'Alternate start URL to use for this execution only',
     },
-    'user-agent': {
+    userAgent: {
       description: 'Alternate user agent to use for this execution only',
     },
     viewport: {
       description:
         'Alternate screen size to use for this execution only. This should be a string formatted as {width}x{height}, for example 1024x768. Will be ignored if screenshot comparison or visual capture is disabled. Provide multiple --viewport arguments to trigger multiple executions.',
     },
-    '[custom-variable]': {
+    '[customVariable]': {
       description:
-        'Pass in custom variables for this execution that are accessible in your steps via {{customVariable}}. For example, providing --first-name=Justin will create a {{firstName}} variable with the value Justin.',
+        'Pass in custom variables for this execution that are accessible in your steps via {{customVariable}}. For example, providing --first-name=Justin will create a {{first-name}} variable with the value Justin. Note that camelCase and kebab-case are both allowed for custom variables.',
     },
   }
 }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,9 @@
     "automated testing",
     "browser testing",
     "automated browser testing",
-    "selenium"
+    "selenium",
+    "cli",
+    "command line interface"
   ],
   "license": "MIT",
   "readmeFilename": "README.md"

--- a/test/cli-helpers.js
+++ b/test/cli-helpers.js
@@ -6,7 +6,7 @@ describe('helpers', function () {
   describe('cleanArgs()', function () {
     it(' should clean up provided input', function () {
       const result = helpers.cleanArgs({
-        'foo-bar': 'biz',
+        'foo-bar': 'baz',
         fooBar: 'biz',
         _: 'value',
         $0: 'value',
@@ -16,7 +16,7 @@ describe('helpers', function () {
         errorOnScreenshotFail: true,
       })
 
-      assert.deepEqual(result, { fooBar: 'biz' })
+      assert.deepEqual(result, { fooBar: 'biz', 'foo-bar': 'baz' })
     })
   })
 

--- a/test/integration/async.js
+++ b/test/integration/async.js
@@ -34,7 +34,7 @@ describe('Async: Get suites', function () {
   this.timeout(0)
   it('should return suites', async () => {
     const data = await GhostInspector.getSuites()
-    assert.strictEqual(data.length, 2)
+    assert.strictEqual(data.length, 3)
   })
 })
 

--- a/test/integration/callbacks.js
+++ b/test/integration/callbacks.js
@@ -44,7 +44,7 @@ describe('Callback: Get suites', function () {
   it('should return suites', (done) => {
     GhostInspector.getSuites((err, data) => {
       assert.strictEqual(err, null)
-      assert.strictEqual(data.length, 2)
+      assert.strictEqual(data.length, 3)
       done()
     })
   })


### PR DESCRIPTION
Converts argument parsing to use `camelCase` for all valid command parameters and disables parameter expansion so `--kebab-case` parameters will be passed intact.