### PR TITLE
add ability to provide raw JSON input for command options

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -15,6 +15,9 @@ require('yargs/yargs')(process.argv.slice(2))
   .option('json', {
     description: 'Provide output in JSON format.',
   })
+  .option('jsonInput', {
+    description: 'Provide options input in JSON format',
+  })
   .commandDir('commands')
   .demandCommand()
   .wrap(120)

--- a/bin/commands/test/execute.spec.js
+++ b/bin/commands/test/execute.spec.js
@@ -364,19 +364,44 @@ describe('execute --immediate=false', function () {
         clientMethodResponse: [{ name: 'My test', _id: '98765' }, null, true],
       })
     })
+
     it('should pass in user variables with hypens', async function () {
-      this.setExpectedExitCode(1)
       await this.testPlainOutput({
         handlerInput: {
           testId: 'my-test-id',
           myVar: 'foobar',
           'my-other-var': 'foobaz',
           immediate: false,
-          errorOnFail: true,
         },
         expectedClientArgs: [
           'my-test-id',
           { myVar: 'foobar', 'my-other-var': 'foobaz', immediate: false },
+        ],
+        expectedOutput: [['Result: My test (98765)']],
+      })
+    })
+
+    it('should pass in raw parameters', async function () {
+      await this.testPlainOutput({
+        handlerInput: {
+          testId: 'my-test-id',
+          myVar: 'foobar',
+          'my-other-var': 'foobaz',
+          duplicateVar: 1,
+          jsonInput: '{"faz": "baz", "duplicateVar": 2, "immediate": true}',
+        },
+        expectedClientArgs: [
+          'my-test-id',
+          {
+            // explicit parameters
+            myVar: 'foobar',
+            'my-other-var': 'foobaz',
+            // raw parameters
+            immediate: true,
+            faz: 'baz',
+            // explicit param overrides raw param
+            duplicateVar: 1,
+          },
         ],
         expectedOutput: [['Result: My test (98765)']],
       })

--- a/bin/helpers.js
+++ b/bin/helpers.js
@@ -7,14 +7,22 @@ const path = require('path')
  * Node.js client without further modification.
  */
 const cleanArgs = (args) => {
-  // make a copy to leave the original intact
-  args = { ...args }
+  let rawArgs = {}
+  if (args.jsonInput) {
+    try {
+      rawArgs = JSON.parse(args.jsonInput)
+    } catch (unused) {}
+  }
+
+  // apply JSON input, then options
+  args = { ...rawArgs, ...args }
 
   // remove yargs cruft & apiKey
   delete args._
   delete args.$0
   delete args.apiKey
   delete args.json
+  delete args.jsonInput
   delete args.errorOnFail
   delete args.errorOnScreenshotFail
 


### PR DESCRIPTION
This mostly accommodates scenarios where the options for command input may already be in JSON format. These could be modified from `{"an-option": "foobar"}` to `--an-option foobar` with `jq` but some fussing would be required. This change will allow us to just pass through the JSON to any command that accepts options using a new `--jsonInput` parameter.