### PR TITLE
adds ngrok support for execution commands + tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,11 +39,6 @@ commands:
             - ~/.npm/_cacache
 
 jobs:
-  node-v8:
-    docker:
-      - image: node:8
-    steps:
-      - test-nodejs
   node-v10:
     docker:
       - image: node:10
@@ -64,7 +59,6 @@ jobs:
 workflows:
   node-multi-build:
     jobs:
-      - node-v8
       - node-v10
       - node-v12
       - node-v14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,32 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added [ngrok](https://ngrok.com/) support to execution commands with `--ngrokTunnel` option
+- Added [ngrok](https://ngrok.com/) support to execution commands with `--ngrokTunnel` option.
+
+### Changed
+
+- Response signature for `GhostInspector.executeTestOnDemand()` has been changed to `[{result}, passing, screenshotComparePassing]` for consistency.
 
 ### Removed
 
-- Removed Node.js 8 support
+- Removed Node.js 8 support.
 
 ## [5.0.4] - 2021-04-29
 
 ### Added
 
-- Added ability to provide `--jsonInput`
+- Added ability to provide `--jsonInput`.
 
 ## [5.0.3] - 2021-04-27
 
 ### Changed
 
-- Force all built-in parameters to use `--camelCase` to allow for user variables using `--kebab-case`
+- Force all built-in parameters to use `--camelCase` to allow for user variables using `--kebab-case`.
 
 ## [5.0.2] - 2021-04-20
 
 ### Changed
 
-- Corrected docs regarding `--errorOnFail` and `--errorOnScreenshotFail`
+- Corrected docs regarding `--errorOnFail` and `--errorOnScreenshotFail`.
 
 ## [5.0.1] - 2021-04-14
 
 ### Added
 
-- Added support for the `ghost-inspector` Command Line Interface
+- Added support for the `ghost-inspector` Command Line Interface.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [6.0.0] - 2021-05-05
+
+### Added
+
+- Added [ngrok](https://ngrok.com/) support to execution commands with `--ngrokTunnel` option
+
+### Removed
+
+- Removed Node.js 8 support
+
+## [5.0.4] - 2021-04-29
+
+### Added
+
+- Added ability to provide `--jsonInput`
+
+## [5.0.3] - 2021-04-27
+
+### Changed
+
+- Force all built-in parameters to use `--camelCase` to allow for user variables using `--kebab-case`
+
+## [5.0.2] - 2021-04-20
+
+### Changed
+
+- Corrected docs regarding `--errorOnFail` and `--errorOnScreenshotFail`
+
+## [5.0.1] - 2021-04-14
+
+### Added
+
+- Added support for the `ghost-inspector` Command Line Interface

--- a/README.md
+++ b/README.md
@@ -785,7 +785,7 @@ const myTest = require('./my-test.json')
 
 // Wait for the result to finish execution before returning
 const options = {
-  wait: true,
+  immediate: false,
 }
 
 // Example using await

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ CLI quickstart:
 
 ```
 ❯ ghost-inspector test execute <testId> \
-  --browser Firefox \
+  --browser firefox \
   --ngrokTunnel localhost:8000 \
   --myVariable "some variable" \
   --errorOnFail

--- a/README.md
+++ b/README.md
@@ -790,16 +790,25 @@ const options = {
 
 // Example using await
 try {
-  const result = await GhostInspector.executeTestOnDemand('[organization-id]', myTest, options)
+  const [result, passing, screenshotPassing] = await GhostInspector.executeTestOnDemand(
+    '[organization-id]',
+    myTest,
+    options,
+  )
 } catch (err) {
   console.error(err)
 }
 
 // Example using a callback
-GhostInspector.executeTestOnDemand('[organization-id]', myTest, options, function (err, result) {
-  if (err) return console.error(err)
-  console.log(`Passing: ${result.passing}`)
-})
+GhostInspector.executeTestOnDemand(
+  '[organization-id]',
+  myTest,
+  options,
+  function (err, result, passing, screenshotPassing) {
+    if (err) return console.error(err)
+    console.log(`Passing: ${result.passing}`)
+  },
+)
 ```
 
 #### `GhostInspector.waitForTestResult(resultId, [options], [callback])`

--- a/README.md
+++ b/README.md
@@ -48,7 +48,11 @@ try {
 CLI quickstart:
 
 ```
-❯ ghost-inspector test execute <testId> --browser Firefox --myVariable "some variable" --errorOnFail
+❯ ghost-inspector test execute <testId> \
+  --browser Firefox \
+  --ngrokTunnel localhost:8000 \
+  --myVariable "some variable" \
+  --errorOnFail
 ```
 
 ### Exit status control for CI systems
@@ -66,6 +70,40 @@ Under an automated build environment it makes sense to have a command return a n
 ❯ ghost-inspector test execute <testId> --errorOnFail --errorOnScreenshotFail
 
 ```
+
+### Creating a secure VPN tunnel with ngrok
+
+The CLI has built-in support for [ngrok](https://ngrok.com/) to make it easier for you to run your tests against a locally-accessible application. In order to set up `ngrok` you will need your access token from [your ngrok account](https://dashboard.ngrok.com/get-started/your-authtoken). To initiate a tunnel on execution use the `--ngrokTunnel` parameter to specify your local endpoint, this can be a port on your local computer or a target on the local network:
+
+```
+❯ ghost-inspector test execute <testId> \
+  --ngrokTunnel localhost:8000 \
+  --ngrokToken '<my-ngrok-token>'
+```
+
+If you prefer you can also set the ngrok token using the environment variable `NGROK_TOKEN`.
+
+#### Using the tunnel URL
+
+Once you trigger your execution the variable `ngrokUrl` will be made available in your test with the URL of the tunnel. You can modify the name of this variable using the option `--ngrokUrlVariable`, for instance you could set it to `{{ appDomain }}` with the following example:
+
+```
+❯ ghost-inspector test execute <testId> \
+  --ngrokTunnel localhost:8000 \
+  --ngrokToken '<my-ngrok-token>'
+  --ngrokUrlVariable 'appDomain'
+```
+
+You can also set the ngrok URL to the start URL of your test or suite:
+
+```
+❯ ghost-inspector test execute <testId> \
+  --ngrokTunnel localhost:8000 \
+  --ngrokToken '<my-ngrok-token>'
+  --ngrokUrlVariable 'startUrl'
+```
+
+If you require additional configuration, you can use [the ngrok configuration file for your system](https://www.npmjs.com/package/ngrok#config) to customize your tunnel.
 
 ### View all available commands for the CLI
 

--- a/README.md
+++ b/README.md
@@ -81,9 +81,11 @@ The CLI has built-in support for [ngrok](https://ngrok.com/) to make it easier f
   --ngrokToken '<my-ngrok-token>'
 ```
 
+**Note**: `--ngrokTunnel` option is not available when using `--immediate`.
+
 If you prefer you can also set the ngrok token using the environment variable `NGROK_TOKEN`.
 
-#### Using the tunnel URL
+#### VPN tunnel URL variable
 
 Once you trigger your execution the variable `ngrokUrl` will be made available in your test with the URL of the tunnel. You can modify the name of this variable using the option `--ngrokUrlVariable`, for instance you could set it to `{{ appDomain }}` with the following example:
 

--- a/bin/commands/suite/execute.js
+++ b/bin/commands/suite/execute.js
@@ -12,7 +12,7 @@ module.exports = {
   },
 
   handler: async function (rawArgs) {
-    // pass raw args to ngrkok
+    // pass raw args to ngrok
     rawArgs = await helpers.ngrokSetup(rawArgs)
 
     const executionArgs = helpers.cleanArgs(rawArgs)

--- a/bin/commands/suite/execute.js
+++ b/bin/commands/suite/execute.js
@@ -11,19 +11,22 @@ module.exports = {
     return yargs
   },
 
-  handler: async function (argv) {
-    const args = helpers.cleanArgs(argv)
+  handler: async function (rawArgs) {
+    // pass raw args to ngrkok
+    rawArgs = await helpers.ngrokSetup(rawArgs)
+
+    const executionArgs = helpers.cleanArgs(rawArgs)
 
     // pull out the suiteId & apiKey so the rest can be passed in verbatim
-    const suiteId = args.suiteId
-    delete args.suiteId
+    const suiteId = executionArgs.suiteId
+    delete executionArgs.suiteId
 
     // execute
-    const client = helpers.getClient(argv)
-    let [result, passing, screenshotPassing] = await client.executeSuite(suiteId, args)
-    const { exitOk } = helpers.resolvePassingStatus(argv, passing, screenshotPassing)
+    const client = helpers.getClient(rawArgs)
+    let [result, passing, screenshotPassing] = await client.executeSuite(suiteId, executionArgs)
+    const { exitOk } = helpers.resolvePassingStatus(rawArgs, passing, screenshotPassing)
 
-    if (argv.json) {
+    if (rawArgs.json) {
       helpers.printJson(result)
     } else {
       // handle multiple results
@@ -32,7 +35,7 @@ module.exports = {
       }
       result.forEach((item) => {
         const { overallPassing } = helpers.resolvePassingStatus(
-          argv,
+          rawArgs,
           item.passing,
           item.screenshotComparePassing,
         )
@@ -43,6 +46,8 @@ module.exports = {
         })
       })
     }
+
+    await helpers.ngrokTeardown(rawArgs)
 
     process.exit(exitOk ? 0 : 1)
   },

--- a/bin/commands/test/execute-on-demand-multiple.spec.js
+++ b/bin/commands/test/execute-on-demand-multiple.spec.js
@@ -1,0 +1,313 @@
+const assert = require('assert')
+const helpers = require('../../helpers')
+
+const onDemandTest = { name: 'My on-demand test' }
+
+describe('execute-on-demand multiple', function () {
+  beforeEach(function () {
+    this.setUpHandler({
+      commandModule: './test/execute-on-demand',
+      clientMethod: 'executeTestOnDemand',
+      clientMethodResponse: [
+        [
+          { name: 'My test', _id: '98765', passing: true },
+          { name: 'My other test', _id: '76543', passing: true },
+        ],
+        true,
+        false,
+      ],
+    })
+
+    // stub for file loading
+    this.loadJsonStub = this.sandbox.stub(helpers, 'loadJsonFile').returns(onDemandTest)
+  })
+
+  it('should print JSON', async function () {
+    await this.testJsonOutput({
+      handlerInput: {
+        organizationId: 'my-org-id',
+        file: 'my-on-demand-test.json',
+        immediate: true,
+      },
+      expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: true }],
+      expectedOutput: [
+        '[{"name":"My test","_id":"98765","passing":true},{"name":"My other test","_id":"76543","passing":true}]',
+      ],
+    })
+  })
+
+  it('should print plain text', async function () {
+    await this.testPlainOutput({
+      handlerInput: {
+        organizationId: 'my-org-id',
+        file: 'my-on-demand-test.json',
+        immediate: true,
+      },
+      expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: true }],
+      expectedOutput: [
+        ['\u001b[32m✓\u001b[39m Result: My test (98765)'],
+        ['\u001b[32m✓\u001b[39m Result: My other test (76543)'],
+      ],
+    })
+  })
+})
+
+describe('execute-on-demand --immediate=true', function () {
+  beforeEach(function () {
+    this.setUpHandler({
+      commandModule: './test/execute-on-demand',
+      clientMethod: 'executeTestOnDemand',
+      clientMethodResponse: [
+        [
+          { name: 'My test', _id: '98765', passing: null, screenshotComparePassing: null },
+          { name: 'My other test', _id: '76543', passing: null, screenshotComparePassing: null },
+        ],
+        null,
+        null,
+      ],
+    })
+
+    // stub for file loading
+    this.loadJsonStub = this.sandbox.stub(helpers, 'loadJsonFile').returns(onDemandTest)
+  })
+
+  it('should ignore --errorOnFail when --immediate', async function () {
+    await this.testPlainOutput({
+      handlerInput: {
+        organizationId: 'my-org-id',
+        file: 'my-on-demand-test.json',
+        immediate: true,
+      },
+      expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: true }],
+      expectedOutput: [['? Result: My test (98765)'], ['? Result: My other test (76543)']],
+    })
+  })
+
+  it('should ignore --errorOnScreenshotFail when --immediate', async function () {
+    await this.testPlainOutput({
+      handlerInput: {
+        organizationId: 'my-org-id',
+        file: 'my-on-demand-test.json',
+        immediate: true,
+        errorOnScreenshotFail: true,
+      },
+      expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: true }],
+      expectedOutput: [['? Result: My test (98765)'], ['? Result: My other test (76543)']],
+    })
+  })
+
+  it('should ignore --errorOnFail and --errorOnScreenshotFail when --immediate', async function () {
+    await this.testPlainOutput({
+      handlerInput: {
+        organizationId: 'my-org-id',
+        file: 'my-on-demand-test.json',
+        immediate: true,
+        errorOnFail: true,
+        errorOnScreenshotFail: true,
+      },
+      expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: true }],
+      expectedOutput: [['? Result: My test (98765)'], ['? Result: My other test (76543)']],
+    })
+  })
+})
+
+describe('execute --immediate=false', function () {
+  describe('one test failing, one screenshot failing', function () {
+    beforeEach(function () {
+      this.setUpHandler({
+        commandModule: './test/execute-on-demand',
+        clientMethod: 'executeTestOnDemand',
+        clientMethodResponse: [
+          [
+            { name: 'My test', _id: '98765', passing: false, screenshotComparePassing: true },
+            { name: 'My other test', _id: '76543', passing: true, screenshotComparePassing: false },
+          ],
+          false,
+          false,
+        ],
+      })
+      // stub for file loading
+      this.loadJsonStub = this.sandbox.stub(helpers, 'loadJsonFile').returns(onDemandTest)
+    })
+
+    it('--errorOnFail should exit with error for one test failing', async function () {
+      this.setExpectedExitCode(1)
+      await this.testPlainOutput({
+        handlerInput: {
+          organizationId: 'my-org-id',
+          file: 'my-on-demand-test.json',
+          immediate: false,
+          errorOnFail: true,
+        },
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
+        expectedOutput: [
+          ['\u001b[31m✖️\u001b[39m Result: My test (98765)'],
+          ['\u001b[32m✓\u001b[39m Result: My other test (76543)'],
+        ],
+      })
+    })
+
+    it('--errorOnScreenshotFail should exit with error for one screenshot failing', async function () {
+      this.setExpectedExitCode(1)
+      await this.testPlainOutput({
+        handlerInput: {
+          organizationId: 'my-org-id',
+          file: 'my-on-demand-test.json',
+          immediate: false,
+          errorOnScreenshotFail: true,
+        },
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
+        expectedOutput: [
+          ['\u001b[32m✓\u001b[39m Result: My test (98765)'],
+          ['\u001b[31m✖️\u001b[39m Result: My other test (76543)'],
+        ],
+      })
+    })
+  })
+
+  describe('test passing, screenshot passing', function () {
+    beforeEach(function () {
+      this.setUpHandler({
+        commandModule: './test/execute-on-demand',
+        clientMethod: 'executeTestOnDemand',
+        clientMethodResponse: [
+          [
+            { name: 'My test', _id: '98765', passing: true, screenshotComparePassing: true },
+            {
+              name: 'My other test',
+              _id: '76543',
+              passing: true,
+              screenshotComparePassing: true,
+            },
+          ],
+          true,
+          true,
+        ],
+      })
+      // stub for file loading
+      this.loadJsonStub = this.sandbox.stub(helpers, 'loadJsonFile').returns(onDemandTest)
+    })
+
+    it('--errorOnFail should exit with success for test passing', async function () {
+      await this.testPlainOutput({
+        handlerInput: {
+          organizationId: 'my-org-id',
+          file: 'my-on-demand-test.json',
+          immediate: false,
+          errorOnFail: true,
+        },
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
+        expectedOutput: [
+          ['\u001b[32m✓\u001b[39m Result: My test (98765)'],
+          ['\u001b[32m✓\u001b[39m Result: My other test (76543)'],
+        ],
+      })
+    })
+
+    it('--errorOnScreenshotFail should exit with error for screenshot failing', async function () {
+      await this.testPlainOutput({
+        handlerInput: {
+          organizationId: 'my-org-id',
+          file: 'my-on-demand-test.json',
+          immediate: false,
+          errorOnScreenshotFail: true,
+        },
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
+        expectedOutput: [
+          ['\u001b[32m✓\u001b[39m Result: My test (98765)'],
+          ['\u001b[32m✓\u001b[39m Result: My other test (76543)'],
+        ],
+      })
+    })
+
+    it('--errorOnFail --errorOnScreenshotFail should exit with error for screenshot failing', async function () {
+      await this.testPlainOutput({
+        handlerInput: {
+          organizationId: 'my-org-id',
+          file: 'my-on-demand-test.json',
+          immediate: false,
+          errorOnFail: true,
+          errorOnScreenshotFail: true,
+        },
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
+        expectedOutput: [
+          ['\u001b[32m✓\u001b[39m Result: My test (98765)'],
+          ['\u001b[32m✓\u001b[39m Result: My other test (76543)'],
+        ],
+      })
+    })
+  })
+
+  describe('one test null, one screenshot null', function () {
+    beforeEach(function () {
+      this.setUpHandler({
+        commandModule: './test/execute-on-demand',
+        clientMethod: 'executeTestOnDemand',
+        clientMethodResponse: [
+          [
+            { name: 'My test', _id: '98765', passing: true, screenshotComparePassing: null },
+            {
+              name: 'My other test',
+              _id: '76543',
+              passing: null,
+              screenshotComparePassing: true,
+            },
+          ],
+          false,
+          false,
+        ],
+      })
+      // stub for file loading
+      this.loadJsonStub = this.sandbox.stub(helpers, 'loadJsonFile').returns(onDemandTest)
+    })
+
+    it('--errorOnFail should exit with fail for one test null', async function () {
+      this.setExpectedExitCode(1)
+      await this.testPlainOutput({
+        handlerInput: {
+          organizationId: 'my-org-id',
+          file: 'my-on-demand-test.json',
+          immediate: false,
+          errorOnFail: true,
+        },
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
+        expectedOutput: [
+          ['\u001b[32m✓\u001b[39m Result: My test (98765)'],
+          ['? Result: My other test (76543)'],
+        ],
+      })
+    })
+
+    it('--errorOnScreenshotFail should exit with error for screenshot null', async function () {
+      this.setExpectedExitCode(1)
+      await this.testPlainOutput({
+        handlerInput: {
+          organizationId: 'my-org-id',
+          file: 'my-on-demand-test.json',
+          immediate: false,
+          errorOnScreenshotFail: true,
+        },
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
+        expectedOutput: [
+          ['? Result: My test (98765)'],
+          ['\u001b[32m✓\u001b[39m Result: My other test (76543)'],
+        ],
+      })
+    })
+
+    it('--errorOnFail --errorOnScreenshotFail should exit with error for screenshot null', async function () {
+      this.setExpectedExitCode(1)
+      await this.testPlainOutput({
+        handlerInput: {
+          organizationId: 'my-org-id',
+          file: 'my-on-demand-test.json',
+          immediate: false,
+          errorOnFail: true,
+          errorOnScreenshotFail: true,
+        },
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
+        expectedOutput: [['? Result: My test (98765)'], ['? Result: My other test (76543)']],
+      })
+    })
+  })
+})

--- a/bin/commands/test/execute-on-demand.spec.js
+++ b/bin/commands/test/execute-on-demand.spec.js
@@ -9,7 +9,11 @@ describe('execute-on-demand', function () {
     this.setUpHandler({
       commandModule: './test/execute-on-demand',
       clientMethod: 'executeTestOnDemand',
-      clientMethodResponse: [{ name: 'My test', _id: '98765', passing: null }, true, false],
+      clientMethodResponse: [
+        { name: 'My test', _id: '98765', passing: true, screenshotComparePassing: false },
+        true,
+        false,
+      ],
     })
 
     // stub for file loading
@@ -27,8 +31,10 @@ describe('execute-on-demand', function () {
         file: 'my-on-demand-test.json',
         immediate: true,
       },
-      expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { wait: false }],
-      expectedOutput: ['{"name":"My test","_id":"98765","passing":null}'],
+      expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: true }],
+      expectedOutput: [
+        '{"name":"My test","_id":"98765","passing":true,"screenshotComparePassing":false}',
+      ],
     })
 
     // assert json file was loaded
@@ -42,7 +48,7 @@ describe('execute-on-demand', function () {
         organizationId: 'my-test-id',
         immediate: true,
       },
-      expectedClientArgs: ['my-test-id', { name: 'My on-demand test' }, { wait: false }],
+      expectedClientArgs: ['my-test-id', { name: 'My on-demand test' }, { immediate: true }],
       expectedOutput: [['\u001b[32m✓\u001b[39m Result: My test (98765)']],
     })
 
@@ -57,7 +63,11 @@ describe('execute --immediate=true', function () {
     this.setUpHandler({
       commandModule: './test/execute-on-demand',
       clientMethod: 'executeTestOnDemand',
-      clientMethodResponse: [{ name: 'My test', _id: '98765' }, null, null],
+      clientMethodResponse: [
+        { name: 'My test', _id: '98765', passing: null, screenshotComparePassing: null },
+        null,
+        null,
+      ],
     })
 
     // stub for file loading
@@ -71,7 +81,7 @@ describe('execute --immediate=true', function () {
         file: 'my-on-demand-test.json',
         immediate: true,
       },
-      expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { wait: false }],
+      expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: true }],
       expectedOutput: [['? Result: My test (98765)']],
     })
   })
@@ -84,7 +94,7 @@ describe('execute --immediate=true', function () {
         immediate: true,
         errorOnScreenshotFail: true,
       },
-      expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { wait: false }],
+      expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: true }],
       expectedOutput: [['? Result: My test (98765)']],
     })
   })
@@ -98,7 +108,7 @@ describe('execute --immediate=true', function () {
         errorOnFail: true,
         errorOnScreenshotFail: true,
       },
-      expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { wait: false }],
+      expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: true }],
       expectedOutput: [['? Result: My test (98765)']],
     })
   })
@@ -122,7 +132,11 @@ describe('execute --immediate=false', function () {
       this.setUpHandler({
         commandModule: './test/execute-on-demand',
         clientMethod: 'executeTestOnDemand',
-        clientMethodResponse: [{ name: 'My test', _id: '98765' }, false, false],
+        clientMethodResponse: [
+          { name: 'My test', _id: '98765', passing: false, screenshotComparePassing: false },
+          false,
+          false,
+        ],
       })
 
       // stub for file loading
@@ -138,7 +152,7 @@ describe('execute --immediate=false', function () {
           immediate: false,
           errorOnFail: true,
         },
-        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { wait: true }],
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
         expectedOutput: [['\u001b[31m✖️\u001b[39m Result: My test (98765)']],
       })
     })
@@ -152,7 +166,7 @@ describe('execute --immediate=false', function () {
           immediate: false,
           errorOnScreenshotFail: true,
         },
-        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { wait: true }],
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
         expectedOutput: [['\u001b[31m✖️\u001b[39m Result: My test (98765)']],
       })
     })
@@ -163,7 +177,11 @@ describe('execute --immediate=false', function () {
       this.setUpHandler({
         commandModule: './test/execute-on-demand',
         clientMethod: 'executeTestOnDemand',
-        clientMethodResponse: [{ name: 'My test', _id: '98765' }, true, false],
+        clientMethodResponse: [
+          { name: 'My test', _id: '98765', passing: true, screenshotComparePassing: false },
+          true,
+          false,
+        ],
       })
 
       // stub for file loading
@@ -179,7 +197,7 @@ describe('execute --immediate=false', function () {
           immediate: false,
           errorOnFail: true,
         },
-        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { wait: true }],
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
         expectedOutput: [['\u001b[32m✓\u001b[39m Result: My test (98765)']],
       })
     })
@@ -193,7 +211,7 @@ describe('execute --immediate=false', function () {
           immediate: false,
           errorOnScreenshotFail: true,
         },
-        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { wait: true }],
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
         expectedOutput: [['\u001b[31m✖️\u001b[39m Result: My test (98765)']],
       })
     })
@@ -208,7 +226,7 @@ describe('execute --immediate=false', function () {
           errorOnFail: true,
           errorOnScreenshotFail: true,
         },
-        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { wait: true }],
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
         expectedOutput: [['\u001b[31m✖️\u001b[39m Result: My test (98765)']],
       })
     })
@@ -219,7 +237,11 @@ describe('execute --immediate=false', function () {
       this.setUpHandler({
         commandModule: './test/execute-on-demand',
         clientMethod: 'executeTestOnDemand',
-        clientMethodResponse: [{ name: 'My test', _id: '98765' }, false, true],
+        clientMethodResponse: [
+          { name: 'My test', _id: '98765', passing: false, screenshotComparePassing: true },
+          false,
+          true,
+        ],
       })
 
       // stub for file loading
@@ -235,7 +257,7 @@ describe('execute --immediate=false', function () {
           immediate: false,
           errorOnFail: true,
         },
-        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { wait: true }],
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
         expectedOutput: [['\u001b[31m✖️\u001b[39m Result: My test (98765)']],
       })
     })
@@ -249,7 +271,7 @@ describe('execute --immediate=false', function () {
           immediate: false,
           errorOnScreenshotFail: true,
         },
-        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { wait: true }],
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
         expectedOutput: [['\u001b[32m✓\u001b[39m Result: My test (98765)']],
       })
     })
@@ -264,7 +286,7 @@ describe('execute --immediate=false', function () {
           errorOnFail: true,
           errorOnScreenshotFail: true,
         },
-        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { wait: true }],
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
         expectedOutput: [['\u001b[31m✖️\u001b[39m Result: My test (98765)']],
       })
     })
@@ -275,7 +297,11 @@ describe('execute --immediate=false', function () {
       this.setUpHandler({
         commandModule: './test/execute-on-demand',
         clientMethod: 'executeTestOnDemand',
-        clientMethodResponse: [{ name: 'My test', _id: '98765' }, true, null],
+        clientMethodResponse: [
+          { name: 'My test', _id: '98765', passing: true, screenshotComparePassing: null },
+          true,
+          null,
+        ],
       })
 
       // stub for file loading
@@ -291,7 +317,7 @@ describe('execute --immediate=false', function () {
           immediate: false,
           errorOnFail: true,
         },
-        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { wait: true }],
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
         expectedOutput: [['\u001b[32m✓\u001b[39m Result: My test (98765)']],
       })
     })
@@ -305,7 +331,7 @@ describe('execute --immediate=false', function () {
           immediate: false,
           errorOnScreenshotFail: true,
         },
-        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { wait: true }],
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
         expectedOutput: [['? Result: My test (98765)']],
       })
     })
@@ -320,7 +346,7 @@ describe('execute --immediate=false', function () {
           errorOnFail: true,
           errorOnScreenshotFail: true,
         },
-        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { wait: true }],
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
         expectedOutput: [['? Result: My test (98765)']],
       })
     })
@@ -331,7 +357,11 @@ describe('execute --immediate=false', function () {
       this.setUpHandler({
         commandModule: './test/execute-on-demand',
         clientMethod: 'executeTestOnDemand',
-        clientMethodResponse: [{ name: 'My test', _id: '98765' }, null, true],
+        clientMethodResponse: [
+          { name: 'My test', _id: '98765', passing: null, screenshotComparePassing: true },
+          null,
+          true,
+        ],
       })
 
       // stub for file loading
@@ -347,7 +377,7 @@ describe('execute --immediate=false', function () {
           immediate: false,
           errorOnFail: true,
         },
-        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { wait: true }],
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
         expectedOutput: [['? Result: My test (98765)']],
       })
     })
@@ -361,7 +391,7 @@ describe('execute --immediate=false', function () {
           immediate: false,
           errorOnScreenshotFail: true,
         },
-        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { wait: true }],
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
         expectedOutput: [['\u001b[32m✓\u001b[39m Result: My test (98765)']],
       })
     })
@@ -376,7 +406,7 @@ describe('execute --immediate=false', function () {
           errorOnFail: true,
           errorOnScreenshotFail: true,
         },
-        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { wait: true }],
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
         expectedOutput: [['? Result: My test (98765)']],
       })
     })
@@ -387,7 +417,11 @@ describe('execute --immediate=false', function () {
       this.setUpHandler({
         commandModule: './test/execute-on-demand',
         clientMethod: 'executeTestOnDemand',
-        clientMethodResponse: [{ name: 'My test', _id: '98765' }, null, true],
+        clientMethodResponse: [
+          { name: 'My test', _id: '98765', passing: null, screenshotComparePassing: true },
+          null,
+          true,
+        ],
       })
       // stub for file loading
       this.loadJsonStub = this.sandbox.stub(helpers, 'loadJsonFile').returns(onDemandTest)
@@ -408,7 +442,7 @@ describe('execute --immediate=false', function () {
         expectedClientArgs: [
           'my-org-id',
           { name: 'My on-demand test', variables: { ngrokUrl: 'some-url' } },
-          { wait: true },
+          { immediate: false },
         ],
         expectedOutput: [
           ["Ngrok URL (some-url) assigned to variable 'ngrokUrl'"],
@@ -433,9 +467,11 @@ describe('execute --immediate=false', function () {
         expectedClientArgs: [
           'my-org-id',
           { name: 'My on-demand test', variables: { ngrokUrl: 'some-url' } },
-          { wait: true },
+          { immediate: false },
         ],
-        expectedOutput: [['{"name":"My test","_id":"98765"}']],
+        expectedOutput: [
+          ['{"name":"My test","_id":"98765","passing":null,"screenshotComparePassing":true}'],
+        ],
       })
     })
 
@@ -455,7 +491,7 @@ describe('execute --immediate=false', function () {
         expectedClientArgs: [
           'my-org-id',
           { name: 'My on-demand test', variables: { ngrokUrl: 'some-url' } },
-          { wait: true },
+          { immediate: false },
         ],
         expectedOutput: [
           ["Ngrok URL (some-url) assigned to variable 'ngrokUrl'"],
@@ -487,7 +523,7 @@ describe('execute --immediate=false', function () {
         expectedClientArgs: [
           'my-org-id',
           { name: 'My on-demand test', variables: { ngrokUrl: 'some-url' } },
-          { wait: true },
+          { immediate: false },
         ],
         expectedOutput: [
           ["Ngrok URL (some-url) assigned to variable 'ngrokUrl'"],
@@ -515,7 +551,7 @@ describe('execute --immediate=false', function () {
         expectedClientArgs: [
           'my-org-id',
           { name: 'My on-demand test', variables: { ngrokUrl: 'some-url' } },
-          { wait: true },
+          { immediate: false },
         ],
         expectedOutput: [
           ["Ngrok URL (some-url) assigned to variable 'ngrokUrl'"],

--- a/bin/helpers.js
+++ b/bin/helpers.js
@@ -233,16 +233,16 @@ const ngrokSetup = async (args) => {
       throw new Error('Cannot use --ngrokTunnel with --immediate')
     }
 
-    const apiKey = process.env.NGROK_TOKEN || args.ngrokToken
+    const ngrokToken = process.env.NGROK_TOKEN || args.ngrokToken
     try {
-      assert.ok(apiKey, 'ngrokToken is required')
+      assert.ok(ngrokToken, 'ngrokToken is required')
     } catch (error) {
       // unwrap assertion error
       throw new Error(error.message)
     }
 
     const connectArgs = {
-      authtoken: args.ngrokToken,
+      authtoken: ngrokToken,
       addr: args.ngrokTunnel,
     }
 
@@ -250,11 +250,15 @@ const ngrokSetup = async (args) => {
       connectArgs.host_header = args.ngrokHostHeader
     }
 
-    const url = await ngrok.connect(connectArgs)
-    args[args.ngrokUrlVariable] = url
+    try {
+      const url = await ngrok.connect(connectArgs)
+      args[args.ngrokUrlVariable] = url
 
-    if (!args.json) {
-      console.log(`Ngrok URL (${url}) assigned to variable '${args.ngrokUrlVariable}'`)
+      if (!args.json) {
+        console.log(`Ngrok URL (${url}) assigned to variable '${args.ngrokUrlVariable}'`)
+      }
+    } catch (error) {
+      throw new Error(error.message)
     }
   }
   return args

--- a/bin/helpers.js
+++ b/bin/helpers.js
@@ -233,7 +233,7 @@ const ngrokSetup = async (args) => {
       throw new Error('Cannot use --ngrokTunnel with --immediate')
     }
 
-    const ngrokToken = process.env.NGROK_TOKEN || args.ngrokToken
+    const ngrokToken = args.ngrokToken || process.env.NGROK_TOKEN
     try {
       assert.ok(ngrokToken, 'ngrokToken is required')
     } catch (error) {

--- a/bin/helpers.js
+++ b/bin/helpers.js
@@ -64,34 +64,34 @@ const getCommonExecutionOptions = () => {
       type: 'string',
     },
     dataFile: {
-      description: 'Path to local CSV file containing a row of variable values for each test run',
+      description: 'Path to local CSV file containing a row of variable values for each test run.',
     },
     disableNotifications: {
-      description: 'Disable all notifications for this execution only when provided',
+      description: 'Disable all notifications for this execution only when provided.',
       type: 'boolean',
     },
     disableVisuals: {
-      description: 'Disable capturing screenshots and video for this execution only when provided',
+      description: 'Disable capturing screenshots and video for this execution only when provided.',
       type: 'boolean',
     },
     errorOnFail: {
       description:
-        'Exit the command with a non-0 status if the test or suite passing value is not `true`. Ignored when used with --immediate',
+        'Exit the command with a non-0 status if the test or suite passing value is not `true`. Ignored when used with --immediate.',
       default: false,
     },
     errorOnScreenshotFail: {
       description:
-        'Exit the command with a non-0 status if the test or suite screenshotComparePassing value is not `true`. Ignored when used with --immediate',
+        'Exit the command with a non-0 status if the test or suite screenshotComparePassing value is not `true`. Ignored when used with --immediate.',
       default: false,
     },
     httpAuthPassword: {
-      description: 'Alternate HTTP authentication password to use for this execution only',
+      description: 'Alternate HTTP authentication password to use for this execution only.',
     },
     httpAuthUsername: {
-      description: 'Alternate HTTP authentication username to use for this execution only',
+      description: 'Alternate HTTP authentication username to use for this execution only.',
     },
     immediate: {
-      description: 'Initiate the execution, then immediate return a response when provided',
+      description: 'Initiate the execution, then immediate return a response when provided.',
       type: 'boolean',
       default: false,
     },
@@ -100,24 +100,24 @@ const getCommonExecutionOptions = () => {
         'Specify the max number of rows to execute simultaneously when executing a test using dataFile.',
     },
     ngrokTunnel: {
-      description: 'TODO',
+      description: 'Create a VPN tunnel to the provided local website using ngrok.',
     },
     ngrokUrlVariable: {
-      description: 'TODO',
+      description: 'The name of the variable that will have the ngrok tunnel URL.',
       default: 'ngrokUrl',
     },
     ngrokHostHeader: {
-      description: 'TODO',
+      description: 'Rewrite the host header for incoming HTTP requests for the ngrok tunnel.',
     },
     ngrokToken: {
-      description: 'TODO',
+      description: 'Your ngrok auth token.',
     },
     region: {
       description:
         'Geo-location for this execution, defaults to "us-east-1". Use `ghost-inspector test-runner-ips` to see all available regions. Provide multiple --region params to trigger multiple executions.',
     },
     screenshotCompareEnabled: {
-      description: 'Enable screenshot comparison for this execution only when provided',
+      description: 'Enable screenshot comparison for this execution only when provided.',
       type: Boolean,
     },
     screenshotCompareThreshold: {

--- a/bin/spec.js
+++ b/bin/spec.js
@@ -103,6 +103,7 @@ describe('CLI', function () {
     require('./commands/test/download.spec')
     require('./commands/test/duplicate.spec')
     require('./commands/test/execute-on-demand.spec')
+    require('./commands/test/execute-on-demand-multiple.spec')
     require('./commands/test/execute.spec')
     require('./commands/test/execute-multiple.spec')
     require('./commands/test/get-running.spec')

--- a/index.js
+++ b/index.js
@@ -509,9 +509,9 @@ class GhostInspector {
     }
     options = options || {}
     options.body = test
-    let result
+    let data
     try {
-      result = await this.request(
+      data = await this.request(
         'POST',
         `/organizations/${organizationId}/on-demand/execute/`,
         options,
@@ -524,6 +524,13 @@ class GhostInspector {
       throw err
     }
 
+    let returnSingleResult = true
+    if (!Array.isArray(data)) {
+      data = [data]
+    } else {
+      returnSingleResult = false
+    }
+
     // maintain support for deprecated 'wait' flag
     let wait = false
     if (options.wait || options.immediate === false) {
@@ -531,13 +538,26 @@ class GhostInspector {
     }
 
     if (wait) {
-      const pollFunction = () => this.getTestResult(result._id)
-      return this.waitForResult(pollFunction, options, callback)
+      data = await Promise.all(
+        data.map((item) => {
+          const pollFunction = () => this.getTestResult(item._id)
+          return this.waitForResult(pollFunction, options, callback)
+        }),
+      )
     }
+
+    // Check results, determine overall pass/fail
+    const passing = this.getOverallResultOutcome(data)
+    const screenshotPassing = this.getOverallResultOutcome(data, 'screenshotComparePassing')
+
+    // map back the single data item
+    data = data.length === 1 && returnSingleResult ? data[0] : data
+
+    // Call back with extra pass/fail parameter
     if (typeof callback === 'function') {
-      callback(null, result)
+      callback(null, data, passing, screenshotPassing)
     }
-    return result
+    return [data, passing, screenshotPassing]
   }
 
   async importTest(suiteId, test, callback) {

--- a/index.js
+++ b/index.js
@@ -523,7 +523,14 @@ class GhostInspector {
       }
       throw err
     }
-    if (options.wait) {
+
+    // maintain support for deprecated 'wait' flag
+    let wait = false
+    if (options.wait || options.immediate === false) {
+      wait = true
+    }
+
+    if (wait) {
       const pollFunction = () => this.getTestResult(result._id)
       return this.waitForResult(pollFunction, options, callback)
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.1",
+        "ngrok": "^4.0.1",
         "request": "^2.88.2",
         "request-promise-native": "^1.0.9",
         "yargs": "^16.2.0"
@@ -166,6 +167,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.0.1.tgz",
+      "integrity": "sha512-Qm9hBEBu18wt1PO2flE7LPb30BHMQt1eQgbV76YntdNk73XZGpn3izvGTYxbGgzXKgbCjiia0uxTd3aTNQrY/g==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -201,11 +213,64 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.5.tgz",
+      "integrity": "sha512-PyRA9sm1Yayuj5OIoJ1hGt2YISX45w9WcFbh6ddT0Z/0yaFxOtGLInr4jUfU1EAFVs0Yfyfev4RNwBlUaHdlDQ==",
+      "dependencies": {
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.1.tgz",
+      "integrity": "sha512-ykFq2zmBGOCbpIXtoVbz4SKY5QriWPh3AjyU4G74RYbtt5yOc5OfaY75ftjg7mikMOla1CTGpX3lLbuJh8DTrQ==",
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "*",
+        "@types/node": "*",
+        "@types/responselike": "*"
+      }
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz",
+      "integrity": "sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A=="
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
+    },
+    "node_modules/@types/keyv": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.1.tgz",
+      "integrity": "sha512-MPtoySlAZQ37VoLaPcTHCu1RWJ4llDkULYZIzOYxlhxBqYPB0RsRlmMU0R6tahtFe27mIdkHV+551ZWV4PLmVw==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "8.10.66",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz",
+      "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw=="
+    },
+    "node_modules/@types/responselike": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
+      "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "node_modules/acorn": {
       "version": "7.4.1",
@@ -389,6 +454,18 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "node_modules/binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
+      "dependencies": {
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -426,6 +503,39 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
+    "node_modules/buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
+      "engines": {
+        "node": ">=0.2.0"
+      }
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.1.tgz",
+      "integrity": "sha512-lt0mJ6YAnsrBErpTMWeu5kl/tg9xMAWjavYTN6VQXM1A/teBITuNcccXsCxF0tDQQJf9DfAaX5O4e0zp0KlfZw==",
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^4.1.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -461,6 +571,17 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "node_modules/chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
+      "dependencies": {
+        "traverse": ">=0.3.0 <0.4"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.1",
@@ -506,6 +627,14 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/clone-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "dependencies": {
+        "mimic-response": "^1.0.0"
       }
     },
     "node_modules/color-convert": {
@@ -606,11 +735,64 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-zip": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.3.3.tgz",
+      "integrity": "sha512-/fy1L4s+4jujqj3kNptWjilFw3E6De8U6XUFvqmh4npN3Vsypm3oT2V0bXcmbBWS+5j5tr4okYaFrOmyZkszEg==",
+      "dependencies": {
+        "binary": "^0.3.0",
+        "graceful-fs": "^4.1.3",
+        "mkpath": "^0.1.0",
+        "nopt": "^3.0.1",
+        "q": "^1.1.2",
+        "readable-stream": "^1.1.8",
+        "touch": "0.0.3"
+      },
+      "bin": {
+        "decompress-zip": "bin/decompress-zip"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
+    },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/define-properties": {
       "version": "1.1.3",
@@ -666,6 +848,14 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/enquirer": {
       "version": "2.3.6",
@@ -1361,6 +1551,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -1413,11 +1617,34 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/got": {
+      "version": "11.8.2",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.2.tgz",
+      "integrity": "sha512-D0QywKgIe30ODs+fm8wMZiAcZjypcCodPNuMz5H9Mny7RJ+IjJ10BdmGW7OM7fHXP+O7r6ZwapQ/YQmMSvB0UQ==",
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.1",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
-      "dev": true
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
     },
     "node_modules/growl": {
       "version": "1.10.5",
@@ -1505,6 +1732,17 @@
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
+    "node_modules/hpagent": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-0.1.1.tgz",
+      "integrity": "sha512-IxJWQiY0vmEjetHdoE9HZjD4Cx+mYTr25tR7JCxXaiI3QxW0YqYyM11KyZbHufoa/piWhMb2+D3FGpMgmA2cFQ==",
+      "optional": true
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+    },
     "node_modules/http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -1517,6 +1755,18 @@
       "engines": {
         "node": ">=0.8",
         "npm": ">=1.3.7"
+      }
+    },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
       }
     },
     "node_modules/ignore": {
@@ -1566,8 +1816,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -1783,8 +2032,7 @@
     "node_modules/isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-      "dev": true
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -1820,6 +2068,11 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
     },
     "node_modules/json-schema": {
       "version": "0.2.3",
@@ -1873,6 +2126,14 @@
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
       "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
       "dev": true
+    },
+    "node_modules/keyv": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.3.tgz",
+      "integrity": "sha512-zdGa2TOpSZPq5mU6iowDARnMBZgtCqJ11dJROFi6tg6kTn4nuUdU09lFyLFSaHrWqpIJ+EBq4E8/Dc0Vx5vLdA==",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -2018,6 +2279,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -2049,6 +2318,14 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -2078,6 +2355,11 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
+    },
+    "node_modules/mkpath": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz",
+      "integrity": "sha1-dVSm+Nhxg0zJe1RisSLEwSTW3pE="
     },
     "node_modules/mocha": {
       "version": "7.2.0",
@@ -2355,6 +2637,28 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "node_modules/ngrok": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/ngrok/-/ngrok-4.0.1.tgz",
+      "integrity": "sha512-1RDEaP6urGt8dVzZ68mlf1799VXucJ3bEcNDOSwWoGUjgXS7MxMw+ngyw/2H/O+EMk1Fj1+Md2Au595rB4lG5w==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@types/node": "^8.10.50",
+        "decompress-zip": "^0.3.2",
+        "got": "^11.5.1",
+        "uuid": "^3.3.2",
+        "yaml": "^1.10.0"
+      },
+      "bin": {
+        "ngrok": "bin/ngrok"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "optionalDependencies": {
+        "hpagent": "^0.1.1"
+      }
+    },
     "node_modules/nise": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/nise/-/nise-4.1.0.tgz",
@@ -2387,6 +2691,17 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      }
+    },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -2415,6 +2730,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-url": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
+      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/oauth-sign": {
@@ -2500,7 +2823,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -2520,6 +2842,14 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/p-limit": {
@@ -2767,6 +3097,15 @@
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
+    "node_modules/pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -2775,12 +3114,32 @@
         "node": ">=6"
       }
     },
+    "node_modules/q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+      "engines": {
+        "node": ">=0.6.0",
+        "teleport": ">=0.2.0"
+      }
+    },
     "node_modules/qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/read-pkg": {
@@ -2866,6 +3225,17 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
       }
     },
     "node_modules/readdirp": {
@@ -2990,6 +3360,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-alpn": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.1.2.tgz",
+      "integrity": "sha512-8OyfzhAtA32LVUsJSke3auIyINcwdh5l3cvYKdKO0nvsYSKuiLfTM5i78PJswFPT8y6cPW+L1v6/hE95chcpDA=="
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2997,6 +3372,14 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/responselike": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
+      "integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
       }
     },
     "node_modules/rimraf": {
@@ -3194,6 +3577,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
     "node_modules/string-width": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
@@ -3334,6 +3722,31 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/touch": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
+      "integrity": "sha1-Ua7z1ElXHU8oel2Hyci0kYGg2x0=",
+      "dependencies": {
+        "nopt": "~1.0.10"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/touch/node_modules/nopt": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+      "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
@@ -3344,6 +3757,14 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/tsconfig-paths": {
@@ -3584,8 +4005,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -3600,6 +4020,14 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/yargs": {
       "version": "16.2.0",
@@ -3890,6 +4318,11 @@
         }
       }
     },
+    "@sindresorhus/is": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.0.1.tgz",
+      "integrity": "sha512-Qm9hBEBu18wt1PO2flE7LPb30BHMQt1eQgbV76YntdNk73XZGpn3izvGTYxbGgzXKgbCjiia0uxTd3aTNQrY/g=="
+    },
     "@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -3925,11 +4358,61 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
+    "@szmarczak/http-timer": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.5.tgz",
+      "integrity": "sha512-PyRA9sm1Yayuj5OIoJ1hGt2YISX45w9WcFbh6ddT0Z/0yaFxOtGLInr4jUfU1EAFVs0Yfyfev4RNwBlUaHdlDQ==",
+      "requires": {
+        "defer-to-connect": "^2.0.0"
+      }
+    },
+    "@types/cacheable-request": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.1.tgz",
+      "integrity": "sha512-ykFq2zmBGOCbpIXtoVbz4SKY5QriWPh3AjyU4G74RYbtt5yOc5OfaY75ftjg7mikMOla1CTGpX3lLbuJh8DTrQ==",
+      "requires": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "*",
+        "@types/node": "*",
+        "@types/responselike": "*"
+      }
+    },
+    "@types/http-cache-semantics": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz",
+      "integrity": "sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A=="
+    },
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
+    },
+    "@types/keyv": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.1.tgz",
+      "integrity": "sha512-MPtoySlAZQ37VoLaPcTHCu1RWJ4llDkULYZIzOYxlhxBqYPB0RsRlmMU0R6tahtFe27mIdkHV+551ZWV4PLmVw==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/node": {
+      "version": "8.10.66",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz",
+      "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw=="
+    },
+    "@types/responselike": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
+      "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "acorn": {
       "version": "7.4.1",
@@ -4065,6 +4548,15 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
+      "requires": {
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
+      }
+    },
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -4096,6 +4588,30 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
+    "buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s="
+    },
+    "cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA=="
+    },
+    "cacheable-request": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.1.tgz",
+      "integrity": "sha512-lt0mJ6YAnsrBErpTMWeu5kl/tg9xMAWjavYTN6VQXM1A/teBITuNcccXsCxF0tDQQJf9DfAaX5O4e0zp0KlfZw==",
+      "requires": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^4.1.0",
+        "responselike": "^2.0.0"
+      }
+    },
     "call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -4122,6 +4638,14 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
+      "requires": {
+        "traverse": ">=0.3.0 <0.4"
+      }
     },
     "chalk": {
       "version": "4.1.1",
@@ -4156,6 +4680,14 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "clone-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "requires": {
+        "mimic-response": "^1.0.0"
       }
     },
     "color-convert": {
@@ -4230,11 +4762,45 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
+    "decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "requires": {
+        "mimic-response": "^3.1.0"
+      },
+      "dependencies": {
+        "mimic-response": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+          "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
+        }
+      }
+    },
+    "decompress-zip": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.3.3.tgz",
+      "integrity": "sha512-/fy1L4s+4jujqj3kNptWjilFw3E6De8U6XUFvqmh4npN3Vsypm3oT2V0bXcmbBWS+5j5tr4okYaFrOmyZkszEg==",
+      "requires": {
+        "binary": "^0.3.0",
+        "graceful-fs": "^4.1.3",
+        "mkpath": "^0.1.0",
+        "nopt": "^3.0.1",
+        "q": "^1.1.2",
+        "readable-stream": "^1.1.8",
+        "touch": "0.0.3"
+      }
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
+    },
+    "defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg=="
     },
     "define-properties": {
       "version": "1.1.3",
@@ -4278,6 +4844,14 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "requires": {
+        "once": "^1.4.0"
+      }
     },
     "enquirer": {
       "version": "2.3.6",
@@ -4799,6 +5373,14 @@
         "has-symbols": "^1.0.1"
       }
     },
+    "get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "requires": {
+        "pump": "^3.0.0"
+      }
+    },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -4839,11 +5421,28 @@
         "type-fest": "^0.20.2"
       }
     },
+    "got": {
+      "version": "11.8.2",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.2.tgz",
+      "integrity": "sha512-D0QywKgIe30ODs+fm8wMZiAcZjypcCodPNuMz5H9Mny7RJ+IjJ10BdmGW7OM7fHXP+O7r6ZwapQ/YQmMSvB0UQ==",
+      "requires": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.1",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      }
+    },
     "graceful-fs": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
-      "dev": true
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
     },
     "growl": {
       "version": "1.10.5",
@@ -4903,6 +5502,17 @@
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
+    "hpagent": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-0.1.1.tgz",
+      "integrity": "sha512-IxJWQiY0vmEjetHdoE9HZjD4Cx+mYTr25tR7JCxXaiI3QxW0YqYyM11KyZbHufoa/piWhMb2+D3FGpMgmA2cFQ==",
+      "optional": true
+    },
+    "http-cache-semantics": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -4911,6 +5521,15 @@
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
+      }
+    },
+    "http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "requires": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
       }
     },
     "ignore": {
@@ -4948,8 +5567,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -5079,8 +5697,7 @@
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-      "dev": true
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
     "isexe": {
       "version": "2.0.0",
@@ -5113,6 +5730,11 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
+    "json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
     },
     "json-schema": {
       "version": "0.2.3",
@@ -5160,6 +5782,14 @@
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
       "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
       "dev": true
+    },
+    "keyv": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.3.tgz",
+      "integrity": "sha512-zdGa2TOpSZPq5mU6iowDARnMBZgtCqJ11dJROFi6tg6kTn4nuUdU09lFyLFSaHrWqpIJ+EBq4E8/Dc0Vx5vLdA==",
+      "requires": {
+        "json-buffer": "3.0.1"
+      }
     },
     "levn": {
       "version": "0.4.1",
@@ -5283,6 +5913,11 @@
         }
       }
     },
+    "lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
+    },
     "lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -5304,6 +5939,11 @@
       "requires": {
         "mime-db": "1.47.0"
       }
+    },
+    "mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -5328,6 +5968,11 @@
       "requires": {
         "minimist": "^1.2.5"
       }
+    },
+    "mkpath": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz",
+      "integrity": "sha1-dVSm+Nhxg0zJe1RisSLEwSTW3pE="
     },
     "mocha": {
       "version": "7.2.0",
@@ -5556,6 +6201,19 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "ngrok": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/ngrok/-/ngrok-4.0.1.tgz",
+      "integrity": "sha512-1RDEaP6urGt8dVzZ68mlf1799VXucJ3bEcNDOSwWoGUjgXS7MxMw+ngyw/2H/O+EMk1Fj1+Md2Au595rB4lG5w==",
+      "requires": {
+        "@types/node": "^8.10.50",
+        "decompress-zip": "^0.3.2",
+        "got": "^11.5.1",
+        "hpagent": "^0.1.1",
+        "uuid": "^3.3.2",
+        "yaml": "^1.10.0"
+      }
+    },
     "nise": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/nise/-/nise-4.1.0.tgz",
@@ -5587,6 +6245,14 @@
         }
       }
     },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "requires": {
+        "abbrev": "1"
+      }
+    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -5612,6 +6278,11 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
+    },
+    "normalize-url": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
+      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
     },
     "oauth-sign": {
       "version": "0.9.0",
@@ -5669,7 +6340,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -5687,6 +6357,11 @@
         "type-check": "^0.4.0",
         "word-wrap": "^1.2.3"
       }
+    },
+    "p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg=="
     },
     "p-limit": {
       "version": "2.3.0",
@@ -5866,15 +6541,34 @@
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+    },
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+    },
+    "quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
     },
     "read-pkg": {
       "version": "2.0.0",
@@ -5940,6 +6634,17 @@
           "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
           "dev": true
         }
+      }
+    },
+    "readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
       }
     },
     "readdirp": {
@@ -6029,11 +6734,24 @@
         "path-parse": "^1.0.6"
       }
     },
+    "resolve-alpn": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.1.2.tgz",
+      "integrity": "sha512-8OyfzhAtA32LVUsJSke3auIyINcwdh5l3cvYKdKO0nvsYSKuiLfTM5i78PJswFPT8y6cPW+L1v6/hE95chcpDA=="
+    },
     "resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
+    },
+    "responselike": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
+      "integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
+      "requires": {
+        "lowercase-keys": "^2.0.0"
+      }
     },
     "rimraf": {
       "version": "3.0.2",
@@ -6176,6 +6894,11 @@
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
     "string-width": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
@@ -6284,6 +7007,24 @@
         "is-number": "^7.0.0"
       }
     },
+    "touch": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
+      "integrity": "sha1-Ua7z1ElXHU8oel2Hyci0kYGg2x0=",
+      "requires": {
+        "nopt": "~1.0.10"
+      },
+      "dependencies": {
+        "nopt": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+          "requires": {
+            "abbrev": "1"
+          }
+        }
+      }
+    },
     "tough-cookie": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
@@ -6292,6 +7033,11 @@
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
       }
+    },
+    "traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk="
     },
     "tsconfig-paths": {
       "version": "3.9.0",
@@ -6479,8 +7225,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "y18n": {
       "version": "5.0.8",
@@ -6492,6 +7237,11 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
     },
     "yargs": {
       "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "http://github.com/ghost-inspector/node-ghost-inspector.git"
   },
   "engines": {
-    "node": ">=10.18.0"
+    "node": ">=10.0"
   },
   "scripts": {
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "chalk": "^4.1.1",
+    "ngrok": "^4.0.1",
     "request": "^2.88.2",
     "request-promise-native": "^1.0.9",
     "yargs": "^16.2.0"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "http://github.com/ghost-inspector/node-ghost-inspector.git"
   },
   "engines": {
-    "node": ">=8.9.0"
+    "node": ">=10.18.0"
   },
   "scripts": {
     "lint": "eslint .",

--- a/test/integration/async.js
+++ b/test/integration/async.js
@@ -253,7 +253,7 @@ describe('Async: Execute on-demand test', function () {
   it('should execute an on-demand test and wait for completion', async () => {
     const test = require('./test.json')
     const organizationId = '547fc38c404e81ff79292e53'
-    const result = await GhostInspector.executeTestOnDemand(organizationId, test, {
+    const [result] = await GhostInspector.executeTestOnDemand(organizationId, test, {
       immediate: false,
     })
     assert.ok(result.passing)

--- a/test/integration/async.js
+++ b/test/integration/async.js
@@ -253,7 +253,9 @@ describe('Async: Execute on-demand test', function () {
   it('should execute an on-demand test and wait for completion', async () => {
     const test = require('./test.json')
     const organizationId = '547fc38c404e81ff79292e53'
-    const result = await GhostInspector.executeTestOnDemand(organizationId, test, { wait: true })
+    const result = await GhostInspector.executeTestOnDemand(organizationId, test, {
+      immediate: false,
+    })
     assert.ok(result.passing)
   })
 })

--- a/test/methods.js
+++ b/test/methods.js
@@ -1376,7 +1376,7 @@ describe('API methods', function () {
       assert.deepEqual(this.callbackSpy.args[0], [null, { _id: '123' }])
     })
 
-    it('should execute on-demand test and poll', async function () {
+    it('should execute on-demand test and poll - legacy wait=true', async function () {
       const result = { _id: '123' }
       // set up a stub to mock waiting for a results
       const waitStub = sinon.stub(this.client, 'waitForResult')
@@ -1415,6 +1415,51 @@ describe('API methods', function () {
       assert.deepEqual(response, { _id: '123' })
       // assert that wait was called
       assert.ok(waitStub.called)
+
+      waitStub.restore()
+    })
+
+    it('should execute on-demand test and poll - immediate=false', async function () {
+      const result = { _id: '123' }
+      // set up a stub to mock waiting for a results
+      const waitStub = sinon.stub(this.client, 'waitForResult')
+      waitStub.callsFake(function (_resultId) {
+        return new Promise(function (resolve) {
+          setTimeout(() => {
+            resolve(result)
+          }, 5)
+        })
+      })
+      // set up success response
+      this.requestStub.resolves({ code: 'SUCCESS', data: result })
+      const options = { immediate: false }
+      const test = { name: 'foo' }
+      const response = await this.client.executeTestOnDemand(
+        'org-123',
+        test,
+        options,
+        this.callbackSpy,
+      )
+      // assert API call
+      const requestOptions = this.requestStub.args[0][0]
+      assert.deepEqual(requestOptions.headers, {
+        'Content-Type': 'application/json',
+        'User-Agent': 'Ghost Inspector Node.js Client',
+      })
+      assert.equal(requestOptions.json, true)
+      assert.equal(requestOptions.method, 'POST')
+      assert.equal(
+        requestOptions.uri,
+        'https://api.ghostinspector.com/v1/organizations/org-123/on-demand/execute/',
+      )
+      assert.deepEqual(requestOptions.body, { apiKey: 'my-api-key', name: 'foo' })
+      assert.equal(requestOptions.formData, undefined)
+      // assert async
+      assert.deepEqual(response, { _id: '123' })
+      // assert that wait was called
+      assert.ok(waitStub.called)
+
+      waitStub.restore()
     })
   })
 

--- a/test/methods.js
+++ b/test/methods.js
@@ -1350,7 +1350,10 @@ describe('API methods', function () {
     })
 
     it('should execute on-demand test', async function () {
-      this.requestStub.resolves({ code: 'SUCCESS', data: { _id: '123' } })
+      this.requestStub.resolves({
+        code: 'SUCCESS',
+        data: { _id: '123', passing: true, screenshotComparePassing: true },
+      })
       const response = await this.client.executeTestOnDemand(
         'org-123',
         { name: 'foo' },
@@ -1371,13 +1374,22 @@ describe('API methods', function () {
       assert.deepEqual(requestOptions.body, { apiKey: 'my-api-key', name: 'foo' })
       assert.equal(requestOptions.formData, undefined)
       // assert async
-      assert.deepEqual(response, { _id: '123' })
+      assert.deepEqual(response, [
+        { _id: '123', passing: true, screenshotComparePassing: true },
+        true,
+        true,
+      ])
       // const callbackArgs = this.callbackSpy.args
-      assert.deepEqual(this.callbackSpy.args[0], [null, { _id: '123' }])
+      assert.deepEqual(this.callbackSpy.args[0], [
+        null,
+        { _id: '123', passing: true, screenshotComparePassing: true },
+        true,
+        true,
+      ])
     })
 
     it('should execute on-demand test and poll - legacy wait=true', async function () {
-      const result = { _id: '123' }
+      const result = { _id: '123', passing: true, screenshotComparePassing: false }
       // set up a stub to mock waiting for a results
       const waitStub = sinon.stub(this.client, 'waitForResult')
       waitStub.callsFake(function (_resultId) {
@@ -1412,7 +1424,11 @@ describe('API methods', function () {
       assert.deepEqual(requestOptions.body, { apiKey: 'my-api-key', name: 'foo' })
       assert.equal(requestOptions.formData, undefined)
       // assert async
-      assert.deepEqual(response, { _id: '123' })
+      assert.deepEqual(response, [
+        { _id: '123', passing: true, screenshotComparePassing: false },
+        true,
+        false,
+      ])
       // assert that wait was called
       assert.ok(waitStub.called)
 
@@ -1420,7 +1436,7 @@ describe('API methods', function () {
     })
 
     it('should execute on-demand test and poll - immediate=false', async function () {
-      const result = { _id: '123' }
+      const result = { _id: '123', passing: true, screenshotComparePassing: false }
       // set up a stub to mock waiting for a results
       const waitStub = sinon.stub(this.client, 'waitForResult')
       waitStub.callsFake(function (_resultId) {
@@ -1455,7 +1471,11 @@ describe('API methods', function () {
       assert.deepEqual(requestOptions.body, { apiKey: 'my-api-key', name: 'foo' })
       assert.equal(requestOptions.formData, undefined)
       // assert async
-      assert.deepEqual(response, { _id: '123' })
+      assert.deepEqual(response, [
+        { _id: '123', passing: true, screenshotComparePassing: false },
+        true,
+        false,
+      ])
       // assert that wait was called
       assert.ok(waitStub.called)
 


### PR DESCRIPTION
Adds `ngrok` support for execution endpoints:

```
❯ ghost-inspector test execute xxx \
  --ngrokTunnel localhost:8000 \
  --ngrokUrlVariable 'startUrl'
```

By default a variable `ngrokUrl` is provided via `variables` which has the tunnel endpoint. This can be customized by providing `--ngrokUrlVariable foobar`.