### PR TITLE
Handle multiple responses for on-demand execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,32 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added [ngrok](https://ngrok.com/) support to execution commands with `--ngrokTunnel` option
+- Added [ngrok](https://ngrok.com/) support to execution commands with `--ngrokTunnel` option.
+
+### Changed
+
+- Response signature for `GhostInspector.executeTestOnDemand()` has been changed to `[{result}, passing, screenshotComparePassing]` for consistency.
 
 ### Removed
 
-- Removed Node.js 8 support
+- Removed Node.js 8 support.
 
 ## [5.0.4] - 2021-04-29
 
 ### Added
 
-- Added ability to provide `--jsonInput`
+- Added ability to provide `--jsonInput`.
 
 ## [5.0.3] - 2021-04-27
 
 ### Changed
 
-- Force all built-in parameters to use `--camelCase` to allow for user variables using `--kebab-case`
+- Force all built-in parameters to use `--camelCase` to allow for user variables using `--kebab-case`.
 
 ## [5.0.2] - 2021-04-20
 
 ### Changed
 
-- Corrected docs regarding `--errorOnFail` and `--errorOnScreenshotFail`
+- Corrected docs regarding `--errorOnFail` and `--errorOnScreenshotFail`.
 
 ## [5.0.1] - 2021-04-14
 
 ### Added
 
-- Added support for the `ghost-inspector` Command Line Interface
+- Added support for the `ghost-inspector` Command Line Interface.

--- a/README.md
+++ b/README.md
@@ -785,7 +785,7 @@ const myTest = require('./my-test.json')
 
 // Wait for the result to finish execution before returning
 const options = {
-  wait: true,
+  immediate: false,
 }
 
 // Example using await

--- a/README.md
+++ b/README.md
@@ -790,16 +790,25 @@ const options = {
 
 // Example using await
 try {
-  const result = await GhostInspector.executeTestOnDemand('[organization-id]', myTest, options)
+  const [result, passing, screenshotPassing] = await GhostInspector.executeTestOnDemand(
+    '[organization-id]',
+    myTest,
+    options,
+  )
 } catch (err) {
   console.error(err)
 }
 
 // Example using a callback
-GhostInspector.executeTestOnDemand('[organization-id]', myTest, options, function (err, result) {
-  if (err) return console.error(err)
-  console.log(`Passing: ${result.passing}`)
-})
+GhostInspector.executeTestOnDemand(
+  '[organization-id]',
+  myTest,
+  options,
+  function (err, result, passing, screenshotPassing) {
+    if (err) return console.error(err)
+    console.log(`Passing: ${result.passing}`)
+  },
+)
 ```
 
 #### `GhostInspector.waitForTestResult(resultId, [options], [callback])`

--- a/bin/commands/test/execute-on-demand-multiple.spec.js
+++ b/bin/commands/test/execute-on-demand-multiple.spec.js
@@ -1,0 +1,313 @@
+const assert = require('assert')
+const helpers = require('../../helpers')
+
+const onDemandTest = { name: 'My on-demand test' }
+
+describe('execute-on-demand multiple', function () {
+  beforeEach(function () {
+    this.setUpHandler({
+      commandModule: './test/execute-on-demand',
+      clientMethod: 'executeTestOnDemand',
+      clientMethodResponse: [
+        [
+          { name: 'My test', _id: '98765', passing: true },
+          { name: 'My other test', _id: '76543', passing: true },
+        ],
+        true,
+        false,
+      ],
+    })
+
+    // stub for file loading
+    this.loadJsonStub = this.sandbox.stub(helpers, 'loadJsonFile').returns(onDemandTest)
+  })
+
+  it('should print JSON', async function () {
+    await this.testJsonOutput({
+      handlerInput: {
+        organizationId: 'my-org-id',
+        file: 'my-on-demand-test.json',
+        immediate: true,
+      },
+      expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: true }],
+      expectedOutput: [
+        '[{"name":"My test","_id":"98765","passing":true},{"name":"My other test","_id":"76543","passing":true}]',
+      ],
+    })
+  })
+
+  it('should print plain text', async function () {
+    await this.testPlainOutput({
+      handlerInput: {
+        organizationId: 'my-org-id',
+        file: 'my-on-demand-test.json',
+        immediate: true,
+      },
+      expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: true }],
+      expectedOutput: [
+        ['\u001b[32m✓\u001b[39m Result: My test (98765)'],
+        ['\u001b[32m✓\u001b[39m Result: My other test (76543)'],
+      ],
+    })
+  })
+})
+
+describe('execute-on-demand --immediate=true', function () {
+  beforeEach(function () {
+    this.setUpHandler({
+      commandModule: './test/execute-on-demand',
+      clientMethod: 'executeTestOnDemand',
+      clientMethodResponse: [
+        [
+          { name: 'My test', _id: '98765', passing: null, screenshotComparePassing: null },
+          { name: 'My other test', _id: '76543', passing: null, screenshotComparePassing: null },
+        ],
+        null,
+        null,
+      ],
+    })
+
+    // stub for file loading
+    this.loadJsonStub = this.sandbox.stub(helpers, 'loadJsonFile').returns(onDemandTest)
+  })
+
+  it('should ignore --errorOnFail when --immediate', async function () {
+    await this.testPlainOutput({
+      handlerInput: {
+        organizationId: 'my-org-id',
+        file: 'my-on-demand-test.json',
+        immediate: true,
+      },
+      expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: true }],
+      expectedOutput: [['? Result: My test (98765)'], ['? Result: My other test (76543)']],
+    })
+  })
+
+  it('should ignore --errorOnScreenshotFail when --immediate', async function () {
+    await this.testPlainOutput({
+      handlerInput: {
+        organizationId: 'my-org-id',
+        file: 'my-on-demand-test.json',
+        immediate: true,
+        errorOnScreenshotFail: true,
+      },
+      expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: true }],
+      expectedOutput: [['? Result: My test (98765)'], ['? Result: My other test (76543)']],
+    })
+  })
+
+  it('should ignore --errorOnFail and --errorOnScreenshotFail when --immediate', async function () {
+    await this.testPlainOutput({
+      handlerInput: {
+        organizationId: 'my-org-id',
+        file: 'my-on-demand-test.json',
+        immediate: true,
+        errorOnFail: true,
+        errorOnScreenshotFail: true,
+      },
+      expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: true }],
+      expectedOutput: [['? Result: My test (98765)'], ['? Result: My other test (76543)']],
+    })
+  })
+})
+
+describe('execute --immediate=false', function () {
+  describe('one test failing, one screenshot failing', function () {
+    beforeEach(function () {
+      this.setUpHandler({
+        commandModule: './test/execute-on-demand',
+        clientMethod: 'executeTestOnDemand',
+        clientMethodResponse: [
+          [
+            { name: 'My test', _id: '98765', passing: false, screenshotComparePassing: true },
+            { name: 'My other test', _id: '76543', passing: true, screenshotComparePassing: false },
+          ],
+          false,
+          false,
+        ],
+      })
+      // stub for file loading
+      this.loadJsonStub = this.sandbox.stub(helpers, 'loadJsonFile').returns(onDemandTest)
+    })
+
+    it('--errorOnFail should exit with error for one test failing', async function () {
+      this.setExpectedExitCode(1)
+      await this.testPlainOutput({
+        handlerInput: {
+          organizationId: 'my-org-id',
+          file: 'my-on-demand-test.json',
+          immediate: false,
+          errorOnFail: true,
+        },
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
+        expectedOutput: [
+          ['\u001b[31m✖️\u001b[39m Result: My test (98765)'],
+          ['\u001b[32m✓\u001b[39m Result: My other test (76543)'],
+        ],
+      })
+    })
+
+    it('--errorOnScreenshotFail should exit with error for one screenshot failing', async function () {
+      this.setExpectedExitCode(1)
+      await this.testPlainOutput({
+        handlerInput: {
+          organizationId: 'my-org-id',
+          file: 'my-on-demand-test.json',
+          immediate: false,
+          errorOnScreenshotFail: true,
+        },
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
+        expectedOutput: [
+          ['\u001b[32m✓\u001b[39m Result: My test (98765)'],
+          ['\u001b[31m✖️\u001b[39m Result: My other test (76543)'],
+        ],
+      })
+    })
+  })
+
+  describe('test passing, screenshot passing', function () {
+    beforeEach(function () {
+      this.setUpHandler({
+        commandModule: './test/execute-on-demand',
+        clientMethod: 'executeTestOnDemand',
+        clientMethodResponse: [
+          [
+            { name: 'My test', _id: '98765', passing: true, screenshotComparePassing: true },
+            {
+              name: 'My other test',
+              _id: '76543',
+              passing: true,
+              screenshotComparePassing: true,
+            },
+          ],
+          true,
+          true,
+        ],
+      })
+      // stub for file loading
+      this.loadJsonStub = this.sandbox.stub(helpers, 'loadJsonFile').returns(onDemandTest)
+    })
+
+    it('--errorOnFail should exit with success for test passing', async function () {
+      await this.testPlainOutput({
+        handlerInput: {
+          organizationId: 'my-org-id',
+          file: 'my-on-demand-test.json',
+          immediate: false,
+          errorOnFail: true,
+        },
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
+        expectedOutput: [
+          ['\u001b[32m✓\u001b[39m Result: My test (98765)'],
+          ['\u001b[32m✓\u001b[39m Result: My other test (76543)'],
+        ],
+      })
+    })
+
+    it('--errorOnScreenshotFail should exit with error for screenshot failing', async function () {
+      await this.testPlainOutput({
+        handlerInput: {
+          organizationId: 'my-org-id',
+          file: 'my-on-demand-test.json',
+          immediate: false,
+          errorOnScreenshotFail: true,
+        },
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
+        expectedOutput: [
+          ['\u001b[32m✓\u001b[39m Result: My test (98765)'],
+          ['\u001b[32m✓\u001b[39m Result: My other test (76543)'],
+        ],
+      })
+    })
+
+    it('--errorOnFail --errorOnScreenshotFail should exit with error for screenshot failing', async function () {
+      await this.testPlainOutput({
+        handlerInput: {
+          organizationId: 'my-org-id',
+          file: 'my-on-demand-test.json',
+          immediate: false,
+          errorOnFail: true,
+          errorOnScreenshotFail: true,
+        },
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
+        expectedOutput: [
+          ['\u001b[32m✓\u001b[39m Result: My test (98765)'],
+          ['\u001b[32m✓\u001b[39m Result: My other test (76543)'],
+        ],
+      })
+    })
+  })
+
+  describe('one test null, one screenshot null', function () {
+    beforeEach(function () {
+      this.setUpHandler({
+        commandModule: './test/execute-on-demand',
+        clientMethod: 'executeTestOnDemand',
+        clientMethodResponse: [
+          [
+            { name: 'My test', _id: '98765', passing: true, screenshotComparePassing: null },
+            {
+              name: 'My other test',
+              _id: '76543',
+              passing: null,
+              screenshotComparePassing: true,
+            },
+          ],
+          false,
+          false,
+        ],
+      })
+      // stub for file loading
+      this.loadJsonStub = this.sandbox.stub(helpers, 'loadJsonFile').returns(onDemandTest)
+    })
+
+    it('--errorOnFail should exit with fail for one test null', async function () {
+      this.setExpectedExitCode(1)
+      await this.testPlainOutput({
+        handlerInput: {
+          organizationId: 'my-org-id',
+          file: 'my-on-demand-test.json',
+          immediate: false,
+          errorOnFail: true,
+        },
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
+        expectedOutput: [
+          ['\u001b[32m✓\u001b[39m Result: My test (98765)'],
+          ['? Result: My other test (76543)'],
+        ],
+      })
+    })
+
+    it('--errorOnScreenshotFail should exit with error for screenshot null', async function () {
+      this.setExpectedExitCode(1)
+      await this.testPlainOutput({
+        handlerInput: {
+          organizationId: 'my-org-id',
+          file: 'my-on-demand-test.json',
+          immediate: false,
+          errorOnScreenshotFail: true,
+        },
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
+        expectedOutput: [
+          ['? Result: My test (98765)'],
+          ['\u001b[32m✓\u001b[39m Result: My other test (76543)'],
+        ],
+      })
+    })
+
+    it('--errorOnFail --errorOnScreenshotFail should exit with error for screenshot null', async function () {
+      this.setExpectedExitCode(1)
+      await this.testPlainOutput({
+        handlerInput: {
+          organizationId: 'my-org-id',
+          file: 'my-on-demand-test.json',
+          immediate: false,
+          errorOnFail: true,
+          errorOnScreenshotFail: true,
+        },
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
+        expectedOutput: [['? Result: My test (98765)'], ['? Result: My other test (76543)']],
+      })
+    })
+  })
+})

--- a/bin/commands/test/execute-on-demand.spec.js
+++ b/bin/commands/test/execute-on-demand.spec.js
@@ -9,7 +9,11 @@ describe('execute-on-demand', function () {
     this.setUpHandler({
       commandModule: './test/execute-on-demand',
       clientMethod: 'executeTestOnDemand',
-      clientMethodResponse: [{ name: 'My test', _id: '98765', passing: null }, true, false],
+      clientMethodResponse: [
+        { name: 'My test', _id: '98765', passing: true, screenshotComparePassing: false },
+        true,
+        false,
+      ],
     })
 
     // stub for file loading
@@ -27,8 +31,10 @@ describe('execute-on-demand', function () {
         file: 'my-on-demand-test.json',
         immediate: true,
       },
-      expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { wait: false }],
-      expectedOutput: ['{"name":"My test","_id":"98765","passing":null}'],
+      expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: true }],
+      expectedOutput: [
+        '{"name":"My test","_id":"98765","passing":true,"screenshotComparePassing":false}',
+      ],
     })
 
     // assert json file was loaded
@@ -42,7 +48,7 @@ describe('execute-on-demand', function () {
         organizationId: 'my-test-id',
         immediate: true,
       },
-      expectedClientArgs: ['my-test-id', { name: 'My on-demand test' }, { wait: false }],
+      expectedClientArgs: ['my-test-id', { name: 'My on-demand test' }, { immediate: true }],
       expectedOutput: [['\u001b[32m✓\u001b[39m Result: My test (98765)']],
     })
 
@@ -57,7 +63,11 @@ describe('execute --immediate=true', function () {
     this.setUpHandler({
       commandModule: './test/execute-on-demand',
       clientMethod: 'executeTestOnDemand',
-      clientMethodResponse: [{ name: 'My test', _id: '98765' }, null, null],
+      clientMethodResponse: [
+        { name: 'My test', _id: '98765', passing: null, screenshotComparePassing: null },
+        null,
+        null,
+      ],
     })
 
     // stub for file loading
@@ -71,7 +81,7 @@ describe('execute --immediate=true', function () {
         file: 'my-on-demand-test.json',
         immediate: true,
       },
-      expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { wait: false }],
+      expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: true }],
       expectedOutput: [['? Result: My test (98765)']],
     })
   })
@@ -84,7 +94,7 @@ describe('execute --immediate=true', function () {
         immediate: true,
         errorOnScreenshotFail: true,
       },
-      expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { wait: false }],
+      expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: true }],
       expectedOutput: [['? Result: My test (98765)']],
     })
   })
@@ -98,7 +108,7 @@ describe('execute --immediate=true', function () {
         errorOnFail: true,
         errorOnScreenshotFail: true,
       },
-      expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { wait: false }],
+      expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: true }],
       expectedOutput: [['? Result: My test (98765)']],
     })
   })
@@ -122,7 +132,11 @@ describe('execute --immediate=false', function () {
       this.setUpHandler({
         commandModule: './test/execute-on-demand',
         clientMethod: 'executeTestOnDemand',
-        clientMethodResponse: [{ name: 'My test', _id: '98765' }, false, false],
+        clientMethodResponse: [
+          { name: 'My test', _id: '98765', passing: false, screenshotComparePassing: false },
+          false,
+          false,
+        ],
       })
 
       // stub for file loading
@@ -138,7 +152,7 @@ describe('execute --immediate=false', function () {
           immediate: false,
           errorOnFail: true,
         },
-        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { wait: true }],
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
         expectedOutput: [['\u001b[31m✖️\u001b[39m Result: My test (98765)']],
       })
     })
@@ -152,7 +166,7 @@ describe('execute --immediate=false', function () {
           immediate: false,
           errorOnScreenshotFail: true,
         },
-        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { wait: true }],
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
         expectedOutput: [['\u001b[31m✖️\u001b[39m Result: My test (98765)']],
       })
     })
@@ -163,7 +177,11 @@ describe('execute --immediate=false', function () {
       this.setUpHandler({
         commandModule: './test/execute-on-demand',
         clientMethod: 'executeTestOnDemand',
-        clientMethodResponse: [{ name: 'My test', _id: '98765' }, true, false],
+        clientMethodResponse: [
+          { name: 'My test', _id: '98765', passing: true, screenshotComparePassing: false },
+          true,
+          false,
+        ],
       })
 
       // stub for file loading
@@ -179,7 +197,7 @@ describe('execute --immediate=false', function () {
           immediate: false,
           errorOnFail: true,
         },
-        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { wait: true }],
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
         expectedOutput: [['\u001b[32m✓\u001b[39m Result: My test (98765)']],
       })
     })
@@ -193,7 +211,7 @@ describe('execute --immediate=false', function () {
           immediate: false,
           errorOnScreenshotFail: true,
         },
-        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { wait: true }],
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
         expectedOutput: [['\u001b[31m✖️\u001b[39m Result: My test (98765)']],
       })
     })
@@ -208,7 +226,7 @@ describe('execute --immediate=false', function () {
           errorOnFail: true,
           errorOnScreenshotFail: true,
         },
-        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { wait: true }],
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
         expectedOutput: [['\u001b[31m✖️\u001b[39m Result: My test (98765)']],
       })
     })
@@ -219,7 +237,11 @@ describe('execute --immediate=false', function () {
       this.setUpHandler({
         commandModule: './test/execute-on-demand',
         clientMethod: 'executeTestOnDemand',
-        clientMethodResponse: [{ name: 'My test', _id: '98765' }, false, true],
+        clientMethodResponse: [
+          { name: 'My test', _id: '98765', passing: false, screenshotComparePassing: true },
+          false,
+          true,
+        ],
       })
 
       // stub for file loading
@@ -235,7 +257,7 @@ describe('execute --immediate=false', function () {
           immediate: false,
           errorOnFail: true,
         },
-        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { wait: true }],
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
         expectedOutput: [['\u001b[31m✖️\u001b[39m Result: My test (98765)']],
       })
     })
@@ -249,7 +271,7 @@ describe('execute --immediate=false', function () {
           immediate: false,
           errorOnScreenshotFail: true,
         },
-        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { wait: true }],
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
         expectedOutput: [['\u001b[32m✓\u001b[39m Result: My test (98765)']],
       })
     })
@@ -264,7 +286,7 @@ describe('execute --immediate=false', function () {
           errorOnFail: true,
           errorOnScreenshotFail: true,
         },
-        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { wait: true }],
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
         expectedOutput: [['\u001b[31m✖️\u001b[39m Result: My test (98765)']],
       })
     })
@@ -275,7 +297,11 @@ describe('execute --immediate=false', function () {
       this.setUpHandler({
         commandModule: './test/execute-on-demand',
         clientMethod: 'executeTestOnDemand',
-        clientMethodResponse: [{ name: 'My test', _id: '98765' }, true, null],
+        clientMethodResponse: [
+          { name: 'My test', _id: '98765', passing: true, screenshotComparePassing: null },
+          true,
+          null,
+        ],
       })
 
       // stub for file loading
@@ -291,7 +317,7 @@ describe('execute --immediate=false', function () {
           immediate: false,
           errorOnFail: true,
         },
-        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { wait: true }],
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
         expectedOutput: [['\u001b[32m✓\u001b[39m Result: My test (98765)']],
       })
     })
@@ -305,7 +331,7 @@ describe('execute --immediate=false', function () {
           immediate: false,
           errorOnScreenshotFail: true,
         },
-        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { wait: true }],
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
         expectedOutput: [['? Result: My test (98765)']],
       })
     })
@@ -320,7 +346,7 @@ describe('execute --immediate=false', function () {
           errorOnFail: true,
           errorOnScreenshotFail: true,
         },
-        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { wait: true }],
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
         expectedOutput: [['? Result: My test (98765)']],
       })
     })
@@ -331,7 +357,11 @@ describe('execute --immediate=false', function () {
       this.setUpHandler({
         commandModule: './test/execute-on-demand',
         clientMethod: 'executeTestOnDemand',
-        clientMethodResponse: [{ name: 'My test', _id: '98765' }, null, true],
+        clientMethodResponse: [
+          { name: 'My test', _id: '98765', passing: null, screenshotComparePassing: true },
+          null,
+          true,
+        ],
       })
 
       // stub for file loading
@@ -347,7 +377,7 @@ describe('execute --immediate=false', function () {
           immediate: false,
           errorOnFail: true,
         },
-        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { wait: true }],
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
         expectedOutput: [['? Result: My test (98765)']],
       })
     })
@@ -361,7 +391,7 @@ describe('execute --immediate=false', function () {
           immediate: false,
           errorOnScreenshotFail: true,
         },
-        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { wait: true }],
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
         expectedOutput: [['\u001b[32m✓\u001b[39m Result: My test (98765)']],
       })
     })
@@ -376,7 +406,7 @@ describe('execute --immediate=false', function () {
           errorOnFail: true,
           errorOnScreenshotFail: true,
         },
-        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { wait: true }],
+        expectedClientArgs: ['my-org-id', { name: 'My on-demand test' }, { immediate: false }],
         expectedOutput: [['? Result: My test (98765)']],
       })
     })
@@ -387,7 +417,11 @@ describe('execute --immediate=false', function () {
       this.setUpHandler({
         commandModule: './test/execute-on-demand',
         clientMethod: 'executeTestOnDemand',
-        clientMethodResponse: [{ name: 'My test', _id: '98765' }, null, true],
+        clientMethodResponse: [
+          { name: 'My test', _id: '98765', passing: null, screenshotComparePassing: true },
+          null,
+          true,
+        ],
       })
       // stub for file loading
       this.loadJsonStub = this.sandbox.stub(helpers, 'loadJsonFile').returns(onDemandTest)
@@ -408,7 +442,7 @@ describe('execute --immediate=false', function () {
         expectedClientArgs: [
           'my-org-id',
           { name: 'My on-demand test', variables: { ngrokUrl: 'some-url' } },
-          { wait: true },
+          { immediate: false },
         ],
         expectedOutput: [
           ["Ngrok URL (some-url) assigned to variable 'ngrokUrl'"],
@@ -433,9 +467,11 @@ describe('execute --immediate=false', function () {
         expectedClientArgs: [
           'my-org-id',
           { name: 'My on-demand test', variables: { ngrokUrl: 'some-url' } },
-          { wait: true },
+          { immediate: false },
         ],
-        expectedOutput: [['{"name":"My test","_id":"98765"}']],
+        expectedOutput: [
+          ['{"name":"My test","_id":"98765","passing":null,"screenshotComparePassing":true}'],
+        ],
       })
     })
 
@@ -455,7 +491,7 @@ describe('execute --immediate=false', function () {
         expectedClientArgs: [
           'my-org-id',
           { name: 'My on-demand test', variables: { ngrokUrl: 'some-url' } },
-          { wait: true },
+          { immediate: false },
         ],
         expectedOutput: [
           ["Ngrok URL (some-url) assigned to variable 'ngrokUrl'"],
@@ -487,7 +523,7 @@ describe('execute --immediate=false', function () {
         expectedClientArgs: [
           'my-org-id',
           { name: 'My on-demand test', variables: { ngrokUrl: 'some-url' } },
-          { wait: true },
+          { immediate: false },
         ],
         expectedOutput: [
           ["Ngrok URL (some-url) assigned to variable 'ngrokUrl'"],
@@ -515,7 +551,7 @@ describe('execute --immediate=false', function () {
         expectedClientArgs: [
           'my-org-id',
           { name: 'My on-demand test', variables: { ngrokUrl: 'some-url' } },
-          { wait: true },
+          { immediate: false },
         ],
         expectedOutput: [
           ["Ngrok URL (some-url) assigned to variable 'ngrokUrl'"],

--- a/bin/spec.js
+++ b/bin/spec.js
@@ -103,6 +103,7 @@ describe('CLI', function () {
     require('./commands/test/download.spec')
     require('./commands/test/duplicate.spec')
     require('./commands/test/execute-on-demand.spec')
+    require('./commands/test/execute-on-demand-multiple.spec')
     require('./commands/test/execute.spec')
     require('./commands/test/execute-multiple.spec')
     require('./commands/test/get-running.spec')

--- a/index.js
+++ b/index.js
@@ -509,9 +509,9 @@ class GhostInspector {
     }
     options = options || {}
     options.body = test
-    let result
+    let data
     try {
-      result = await this.request(
+      data = await this.request(
         'POST',
         `/organizations/${organizationId}/on-demand/execute/`,
         options,
@@ -524,6 +524,13 @@ class GhostInspector {
       throw err
     }
 
+    let returnSingleResult = true
+    if (!Array.isArray(data)) {
+      data = [data]
+    } else {
+      returnSingleResult = false
+    }
+
     // maintain support for deprecated 'wait' flag
     let wait = false
     if (options.wait || options.immediate === false) {
@@ -531,13 +538,26 @@ class GhostInspector {
     }
 
     if (wait) {
-      const pollFunction = () => this.getTestResult(result._id)
-      return this.waitForResult(pollFunction, options, callback)
+      data = await Promise.all(
+        data.map((item) => {
+          const pollFunction = () => this.getTestResult(item._id)
+          return this.waitForResult(pollFunction, options, callback)
+        }),
+      )
     }
+
+    // Check results, determine overall pass/fail
+    const passing = this.getOverallResultOutcome(data)
+    const screenshotPassing = this.getOverallResultOutcome(data, 'screenshotComparePassing')
+
+    // map back the single data item
+    data = data.length === 1 && returnSingleResult ? data[0] : data
+
+    // Call back with extra pass/fail parameter
     if (typeof callback === 'function') {
-      callback(null, result)
+      callback(null, data, passing, screenshotPassing)
     }
-    return result
+    return [data, passing, screenshotPassing]
   }
 
   async importTest(suiteId, test, callback) {

--- a/index.js
+++ b/index.js
@@ -523,7 +523,14 @@ class GhostInspector {
       }
       throw err
     }
-    if (options.wait) {
+
+    // maintain support for deprecated 'wait' flag
+    let wait = false
+    if (options.wait || options.immediate === false) {
+      wait = true
+    }
+
+    if (wait) {
       const pollFunction = () => this.getTestResult(result._id)
       return this.waitForResult(pollFunction, options, callback)
     }

--- a/test/integration/async.js
+++ b/test/integration/async.js
@@ -253,7 +253,7 @@ describe('Async: Execute on-demand test', function () {
   it('should execute an on-demand test and wait for completion', async () => {
     const test = require('./test.json')
     const organizationId = '547fc38c404e81ff79292e53'
-    const result = await GhostInspector.executeTestOnDemand(organizationId, test, {
+    const [result] = await GhostInspector.executeTestOnDemand(organizationId, test, {
       immediate: false,
     })
     assert.ok(result.passing)

--- a/test/integration/async.js
+++ b/test/integration/async.js
@@ -253,7 +253,9 @@ describe('Async: Execute on-demand test', function () {
   it('should execute an on-demand test and wait for completion', async () => {
     const test = require('./test.json')
     const organizationId = '547fc38c404e81ff79292e53'
-    const result = await GhostInspector.executeTestOnDemand(organizationId, test, { wait: true })
+    const result = await GhostInspector.executeTestOnDemand(organizationId, test, {
+      immediate: false,
+    })
     assert.ok(result.passing)
   })
 })

--- a/test/methods.js
+++ b/test/methods.js
@@ -1376,7 +1376,7 @@ describe('API methods', function () {
       assert.deepEqual(this.callbackSpy.args[0], [null, { _id: '123' }])
     })
 
-    it('should execute on-demand test and poll', async function () {
+    it('should execute on-demand test and poll - legacy wait=true', async function () {
       const result = { _id: '123' }
       // set up a stub to mock waiting for a results
       const waitStub = sinon.stub(this.client, 'waitForResult')
@@ -1415,6 +1415,51 @@ describe('API methods', function () {
       assert.deepEqual(response, { _id: '123' })
       // assert that wait was called
       assert.ok(waitStub.called)
+
+      waitStub.restore()
+    })
+
+    it('should execute on-demand test and poll - immediate=false', async function () {
+      const result = { _id: '123' }
+      // set up a stub to mock waiting for a results
+      const waitStub = sinon.stub(this.client, 'waitForResult')
+      waitStub.callsFake(function (_resultId) {
+        return new Promise(function (resolve) {
+          setTimeout(() => {
+            resolve(result)
+          }, 5)
+        })
+      })
+      // set up success response
+      this.requestStub.resolves({ code: 'SUCCESS', data: result })
+      const options = { immediate: false }
+      const test = { name: 'foo' }
+      const response = await this.client.executeTestOnDemand(
+        'org-123',
+        test,
+        options,
+        this.callbackSpy,
+      )
+      // assert API call
+      const requestOptions = this.requestStub.args[0][0]
+      assert.deepEqual(requestOptions.headers, {
+        'Content-Type': 'application/json',
+        'User-Agent': 'Ghost Inspector Node.js Client',
+      })
+      assert.equal(requestOptions.json, true)
+      assert.equal(requestOptions.method, 'POST')
+      assert.equal(
+        requestOptions.uri,
+        'https://api.ghostinspector.com/v1/organizations/org-123/on-demand/execute/',
+      )
+      assert.deepEqual(requestOptions.body, { apiKey: 'my-api-key', name: 'foo' })
+      assert.equal(requestOptions.formData, undefined)
+      // assert async
+      assert.deepEqual(response, { _id: '123' })
+      // assert that wait was called
+      assert.ok(waitStub.called)
+
+      waitStub.restore()
     })
   })
 

--- a/test/methods.js
+++ b/test/methods.js
@@ -1350,7 +1350,10 @@ describe('API methods', function () {
     })
 
     it('should execute on-demand test', async function () {
-      this.requestStub.resolves({ code: 'SUCCESS', data: { _id: '123' } })
+      this.requestStub.resolves({
+        code: 'SUCCESS',
+        data: { _id: '123', passing: true, screenshotComparePassing: true },
+      })
       const response = await this.client.executeTestOnDemand(
         'org-123',
         { name: 'foo' },
@@ -1371,13 +1374,22 @@ describe('API methods', function () {
       assert.deepEqual(requestOptions.body, { apiKey: 'my-api-key', name: 'foo' })
       assert.equal(requestOptions.formData, undefined)
       // assert async
-      assert.deepEqual(response, { _id: '123' })
+      assert.deepEqual(response, [
+        { _id: '123', passing: true, screenshotComparePassing: true },
+        true,
+        true,
+      ])
       // const callbackArgs = this.callbackSpy.args
-      assert.deepEqual(this.callbackSpy.args[0], [null, { _id: '123' }])
+      assert.deepEqual(this.callbackSpy.args[0], [
+        null,
+        { _id: '123', passing: true, screenshotComparePassing: true },
+        true,
+        true,
+      ])
     })
 
     it('should execute on-demand test and poll - legacy wait=true', async function () {
-      const result = { _id: '123' }
+      const result = { _id: '123', passing: true, screenshotComparePassing: false }
       // set up a stub to mock waiting for a results
       const waitStub = sinon.stub(this.client, 'waitForResult')
       waitStub.callsFake(function (_resultId) {
@@ -1412,7 +1424,11 @@ describe('API methods', function () {
       assert.deepEqual(requestOptions.body, { apiKey: 'my-api-key', name: 'foo' })
       assert.equal(requestOptions.formData, undefined)
       // assert async
-      assert.deepEqual(response, { _id: '123' })
+      assert.deepEqual(response, [
+        { _id: '123', passing: true, screenshotComparePassing: false },
+        true,
+        false,
+      ])
       // assert that wait was called
       assert.ok(waitStub.called)
 
@@ -1420,7 +1436,7 @@ describe('API methods', function () {
     })
 
     it('should execute on-demand test and poll - immediate=false', async function () {
-      const result = { _id: '123' }
+      const result = { _id: '123', passing: true, screenshotComparePassing: false }
       // set up a stub to mock waiting for a results
       const waitStub = sinon.stub(this.client, 'waitForResult')
       waitStub.callsFake(function (_resultId) {
@@ -1455,7 +1471,11 @@ describe('API methods', function () {
       assert.deepEqual(requestOptions.body, { apiKey: 'my-api-key', name: 'foo' })
       assert.equal(requestOptions.formData, undefined)
       // assert async
-      assert.deepEqual(response, { _id: '123' })
+      assert.deepEqual(response, [
+        { _id: '123', passing: true, screenshotComparePassing: false },
+        true,
+        false,
+      ])
       // assert that wait was called
       assert.ok(waitStub.called)
 


### PR DESCRIPTION
Adds support for multiple responses from the on-demand execution endpoint (previously missed). Also cleans up a few inconsistencies:

 * adds `immediate` argument to `executeTestOnDemand()` for consistency, maintains `wait` argument for backwards compatibility,
 * changes  response signature from `{result}` to `[{result}, passing, screenshotComparePassing]` for `executeTestOnDemand()` for consistency
