### PR TITLE
On demand error options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.0.1] - 2021-05-05
+
+### Added
+
+- Added explicit options for `--errorOnFail` and `--errorOnScreenshotFail` to `ghost-inspector test execute-on-demand` command.
+
 ## [6.0.0] - 2021-05-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [6.0.1] - 2021-05-05
+## [6.0.1] - 2021-05-10
 
 ### Added
 
 - Added explicit options for `--errorOnFail` and `--errorOnScreenshotFail` to `ghost-inspector test execute-on-demand` command.
 
-## [6.0.0] - 2021-05-05
+## [6.0.0] - 2021-05-10
 
 ### Added
 

--- a/bin/commands/test/execute-on-demand.js
+++ b/bin/commands/test/execute-on-demand.js
@@ -7,6 +7,16 @@ module.exports = {
 
   builder: (yargs) => {
     yargs.options({
+      errorOnFail: {
+        description:
+          'Exit the command with a non-0 status if the test passing value is not `true`. Ignored when used with --immediate.',
+        default: false,
+      },
+      errorOnScreenshotFail: {
+        description:
+          'Exit the command with a non-0 status if the test screenshotComparePassing value is not `true`. Ignored when used with --immediate.',
+        default: false,
+      },
       immediate: {
         description: 'Initiate the execution, then immediate return a response when provided',
         type: 'boolean',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ghost-inspector",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ghost-inspector",
-      "version": "6.0.0",
+      "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost-inspector",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Ghost Inspector CLI and API Library for Node.js",
   "homepage": "https://github.com/ghost-inspector/node-ghost-inspector",
   "author": {


### PR DESCRIPTION
Adds missing explicit options for `errorOnFail` and `errorOnScreenshotFail` for execute on demand. These options still work without these definitions, this change just explicitly lists them in the command help:

```
ghost-inspector test execute-on-demand <organizationId> <file> [options]

Execute an on-demand test against your organization providing the path to your local JSON <file>.

Options:
  --version                Show version number                                                                 [boolean]
  --apiKey                 Your Ghost Inspector API key. You may also pass GHOST_INSPECTOR_API_KEY through your
                           environment.
  --json                   Provide output in JSON format.
  --jsonInput              Provide options input in JSON format
  --help                   Show help                                                                           [boolean]
  --errorOnFail            Exit the command with a non-0 status if the test passing value is not `true`. Ignored when
                           used with --immediate.                                                       [default: false]
  --errorOnScreenshotFail  Exit the command with a non-0 status if the test screenshotComparePassing value is not
                           `true`. Ignored when used with --immediate.                                  [default: false]
  --immediate              Initiate the execution, then immediate return a response when provided
                                                                                              [boolean] [default: false]

```