### PR TITLE
fix boolean option types for CI flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.0.2] - 2021-05-13
+
+### Changed
+
+- Adjust options `--errorOnFail` and `--errorOnScreenshotFail` to be `boolean` type to allow for implicit `true` when provided.
+
 ## [6.0.1] - 2021-05-10
 
 ### Added

--- a/bin/commands/test/execute-on-demand.js
+++ b/bin/commands/test/execute-on-demand.js
@@ -11,11 +11,13 @@ module.exports = {
         description:
           'Exit the command with a non-0 status if the test passing value is not `true`. Ignored when used with --immediate.',
         default: false,
+        type: 'boolean',
       },
       errorOnScreenshotFail: {
         description:
           'Exit the command with a non-0 status if the test screenshotComparePassing value is not `true`. Ignored when used with --immediate.',
         default: false,
+        type: 'boolean',
       },
       immediate: {
         description: 'Initiate the execution, then immediate return a response when provided',

--- a/bin/helpers.js
+++ b/bin/helpers.js
@@ -78,11 +78,13 @@ const getCommonExecutionOptions = () => {
       description:
         'Exit the command with a non-0 status if the test or suite passing value is not `true`. Ignored when used with --immediate.',
       default: false,
+      type: 'boolean',
     },
     errorOnScreenshotFail: {
       description:
         'Exit the command with a non-0 status if the test or suite screenshotComparePassing value is not `true`. Ignored when used with --immediate.',
       default: false,
+      type: 'boolean',
     },
     httpAuthPassword: {
       description: 'Alternate HTTP authentication password to use for this execution only.',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ghost-inspector",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ghost-inspector",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost-inspector",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "Ghost Inspector CLI and API Library for Node.js",
   "homepage": "https://github.com/ghost-inspector/node-ghost-inspector",
   "author": {


### PR DESCRIPTION
Adjusts the `--errorOnFail` and `--errorOnScreenshotFail` flags to be explicitly `type: boolean`, this allows for implicit `true` value when the option is provided without an explicit value.