### PR TITLE
add internal param for integration tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.0.6] - 2021-07-27
+
+### Changed
+
+- Add internal parameter for tagging integrations.
+
 ## [6.0.5] - 2021-07-27
 
 ### Changed

--- a/bin/helpers.js
+++ b/bin/helpers.js
@@ -37,8 +37,6 @@ const cleanArgs = (args) => {
   return args
 }
 
-
-
 /**
  * Abstract the Ghost Inspector client to customize connection details.
  */

--- a/bin/helpers.js
+++ b/bin/helpers.js
@@ -26,6 +26,7 @@ const cleanArgs = (args) => {
   delete args.jsonInput
   delete args.errorOnFail
   delete args.errorOnScreenshotFail
+  delete args.giIntegration
 
   // delete ngrok stuff
   delete args.ngrokTunnel
@@ -35,6 +36,8 @@ const cleanArgs = (args) => {
 
   return args
 }
+
+
 
 /**
  * Abstract the Ghost Inspector client to customize connection details.
@@ -48,8 +51,14 @@ const getClient = (args) => {
     throw new Error(error.message)
   }
 
+  // check for integration details
+  let integration = ''
+  if (args.giIntegration) {
+    integration = ` - ${args.giIntegration}`
+  }
+
   const client = require('../index')(apiKey)
-  client.userAgent = `${client.userAgent} CLI`
+  client.userAgent = `Ghost Inspector CLI${integration}`
   return client
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ghost-inspector",
-  "version": "6.0.5",
+  "version": "6.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ghost-inspector",
-      "version": "6.0.5",
+      "version": "6.0.6",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost-inspector",
-  "version": "6.0.5",
+  "version": "6.0.6",
   "description": "Ghost Inspector CLI and API Library for Node.js",
   "homepage": "https://github.com/ghost-inspector/node-ghost-inspector",
   "author": {


### PR DESCRIPTION
# Description

Modifies the default user agent to be `Ghost Inspector CLI` and adds a new internal parameter to allow for integration tracking. 

Example:

```js
ghost-inspector suite execute xxxx --giIntegration CircleCI
```

This will result in a custom user agent:

```
GET /healthcheck/ 200 2 - 0.486 ms (Ghost Inspector CLI - CircleCI)

```

From this we can update our existing integrations that are able to use the CLI to get better insight on usage.

# Security impacts

None.

# Deployment requirements

N/A