### PR TITLE
disable macos build

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -30,8 +30,9 @@ jobs:
         include:
           - os: ubuntu-latest
             binary: -linux
-          - os: macos-latest
-            binary: -macos
+          # macos build not working properly, disabling for now
+          # - os: macos-latest
+          #   binary: -macos
           - os: windows-latest
             binary: .exe
     steps:


### PR DESCRIPTION
# Description

The linux and Windows build look like they're working perfectly 👌🏻 , however the macos build has some issues: 

```
❯ ./ghost-inspector-macos
dyld: Library not loaded: /usr/local/opt/icu4c/lib/libicui18n.69.dylib
  Referenced from: /var/folders/d2/bbwsdgr97h9__0hgtk8wd58w0000gn/T/caxa/applications/ghost-inspector-macos/8qjecjoc3p/0/node_modules/.bin/node
  Reason: image not found
```

Disabling for now, I'll circle back later on and figure it out. For now I think these other two binaries solve enough of the problem for us 👍🏻 

# Security impacts

N/A

# Deployment requirements

N/A
